### PR TITLE
NDRS-967: restrict functionality of SecretKey

### DIFF
--- a/execution_engine/src/core/engine_state/execute_request.rs
+++ b/execution_engine/src/core/engine_state/execute_request.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use casper_types::{AsymmetricType, ProtocolVersion, PublicKey, SecretKey};
+use casper_types::{ProtocolVersion, PublicKey, SecretKey};
 
 use super::deploy_item::DeployItem;
 use crate::shared::newtypes::Blake2bHash;

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -42,10 +42,10 @@ use casper_types::{
         standard_payment::METHOD_PAY,
         SystemContractType,
     },
-    AccessRights, AsymmetricType, CLType, CLTyped, CLValue, Contract, ContractHash,
-    ContractPackage, ContractPackageHash, ContractWasm, ContractWasmHash, DeployHash, EntryPoint,
-    EntryPointAccess, EntryPointType, EntryPoints, EraId, Key, Parameter, Phase, ProtocolVersion,
-    PublicKey, RuntimeArgs, SecretKey, URef, U512,
+    AccessRights, CLType, CLTyped, CLValue, Contract, ContractHash, ContractPackage,
+    ContractPackageHash, ContractWasm, ContractWasmHash, DeployHash, EntryPoint, EntryPointAccess,
+    EntryPointType, EntryPoints, EraId, Key, Parameter, Phase, ProtocolVersion, PublicKey,
+    RuntimeArgs, SecretKey, URef, U512,
 };
 
 use crate::{

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -3360,9 +3360,7 @@ mod tests {
         result,
     };
 
-    use casper_types::{
-        gens::*, AccessRights, AsymmetricType, CLType, CLValue, Key, PublicKey, SecretKey, URef,
-    };
+    use casper_types::{gens::*, AccessRights, CLType, CLValue, Key, PublicKey, SecretKey, URef};
 
     use super::extract_urefs;
 

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -19,9 +19,7 @@ use casper_execution_engine::{
         motes::Motes, newtypes::Blake2bHash, system_config::SystemConfig, wasm_config::WasmConfig,
     },
 };
-use casper_types::{
-    account::AccountHash, AsymmetricType, ProtocolVersion, PublicKey, SecretKey, U512,
-};
+use casper_types::{account::AccountHash, ProtocolVersion, PublicKey, SecretKey, U512};
 
 use super::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -21,7 +21,7 @@
 //! The test could be written as follows:
 //! ```no_run
 //! use casper_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
-//! use casper_types::{U512, RuntimeArgs, runtime_args, PublicKey, account::AccountHash, SecretKey, AsymmetricType};
+//! use casper_types::{U512, RuntimeArgs, runtime_args, PublicKey, account::AccountHash, SecretKey};
 //!
 //! const MY_ACCOUNT: [u8; 32] = [7u8; 32];
 //! const MY_ADDR: [u8; 32] = [8u8; 32];

--- a/execution_engine_testing/tests/src/test/deploy/receipts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/receipts.rs
@@ -8,8 +8,8 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST;
 use casper_types::{
-    account::AccountHash, runtime_args, AccessRights, AsymmetricType, DeployHash, PublicKey,
-    RuntimeArgs, SecretKey, Transfer, TransferAddr, U512,
+    account::AccountHash, runtime_args, AccessRights, DeployHash, PublicKey, RuntimeArgs,
+    SecretKey, Transfer, TransferAddr, U512,
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -6,8 +6,8 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{core, core::ValidationError, shared::newtypes::Blake2bHash};
 use casper_types::{
-    account::AccountHash, runtime_args, AccessRights, AsymmetricType, Key, PublicKey, RuntimeArgs,
-    SecretKey, URef, U512,
+    account::AccountHash, runtime_args, AccessRights, Key, PublicKey, RuntimeArgs, SecretKey, URef,
+    U512,
 };
 
 const TRANSFER_ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/regression/eco_863.rs
+++ b/execution_engine_testing/tests/src/test/regression/eco_863.rs
@@ -13,8 +13,7 @@ use casper_execution_engine::{
     shared::motes::Motes,
 };
 use casper_types::{
-    account::AccountHash, runtime_args, ApiError, AsymmetricType, Key, PublicKey, RuntimeArgs,
-    SecretKey, U512,
+    account::AccountHash, runtime_args, ApiError, Key, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_FAUCET_STORED: &str = "faucet_stored.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -16,7 +16,7 @@ use casper_execution_engine::{
 use casper_types::{
     runtime_args,
     system::auction::{DelegationRate, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID, METHOD_SLASH},
-    AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    PublicKey, RuntimeArgs, SecretKey, U512,
 };
 use once_cell::sync::Lazy;
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -17,7 +17,7 @@ use casper_types::{
     account::AccountHash,
     runtime_args,
     system::auction::{DelegationRate, ARG_DELEGATOR, ARG_VALIDATOR},
-    AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -23,7 +23,7 @@ use casper_types::{
         },
         mint::TOTAL_SUPPLY_KEY,
     },
-    AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -20,7 +20,7 @@ use casper_types::{
         Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
         ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH,
     },
-    AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -24,7 +24,7 @@ use casper_types::{
     contracts::DEFAULT_ENTRY_POINT_NAME,
     runtime_args,
     system::auction::{self, DelegationRate},
-    AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ENTRY_POINT_NAME: &str = "create_purse";

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -17,7 +17,7 @@ use casper_execution_engine::{
 use casper_types::{
     runtime_args,
     system::auction::{self, DelegationRate, BLOCK_REWARD, INITIAL_ERA_ID},
-    AsymmetricType, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_597.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_597.rs
@@ -6,8 +6,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
 use casper_types::{
-    account::AccountHash, system::auction, ApiError, AsymmetricType, PublicKey, RuntimeArgs,
-    SecretKey,
+    account::AccountHash, system::auction, ApiError, PublicKey, RuntimeArgs, SecretKey,
 };
 
 const CONTRACT_EE_597_REGRESSION: &str = "ee_597_regression.wasm";

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -15,7 +15,7 @@ use casper_types::{
     account::AccountHash,
     runtime_args,
     system::auction::{self, DelegationRate},
-    ApiError, AsymmetricType, PublicKey, RuntimeArgs, SecretKey, U512,
+    ApiError, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_AMOUNT: &str = "amount";

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -19,7 +19,7 @@ use casper_types::{
         auction::{Bids, DelegationRate, SeigniorageRecipientsSnapshot, BLOCK_REWARD},
         mint::TOTAL_SUPPLY_KEY,
     },
-    AsymmetricType, CLValue, ContractHash, EraId, Key, ProtocolVersion, PublicKey, SecretKey, U512,
+    CLValue, ContractHash, EraId, Key, ProtocolVersion, PublicKey, SecretKey, U512,
 };
 
 static ACCOUNT_1_PK: Lazy<PublicKey> = Lazy::new(|| {

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -36,7 +36,7 @@ use casper_types::{
             ERA_ID_KEY, INITIAL_ERA_ID,
         },
     },
-    AsymmetricType, EraId, PublicKey, RuntimeArgs, SecretKey, U512,
+    EraId, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_TARGET: &str = "target";

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -21,7 +21,7 @@ use casper_types::{
         ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR,
         BLOCK_REWARD, DELEGATION_RATE_DENOMINATOR, METHOD_DISTRIBUTE,
     },
-    AsymmetricType, EraId, Key, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    EraId, Key, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_ENTRY_POINT: &str = "entry_point";

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -28,7 +28,7 @@ use casper_types::{
         self, Bids, DelegationRate, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID,
         METHOD_SLASH,
     },
-    ApiError, AsymmetricType, EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    ApiError, EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -16,9 +16,7 @@ use casper_execution_engine::{
     },
     shared::{motes::Motes, stored_value::StoredValue},
 };
-use casper_types::{
-    system::auction::DelegationRate, AsymmetricType, ProtocolVersion, PublicKey, SecretKey, U512,
-};
+use casper_types::{system::auction::DelegationRate, ProtocolVersion, PublicKey, SecretKey, U512};
 
 const GENESIS_CONFIG_HASH: [u8; 32] = [127; 32];
 const ACCOUNT_1_BONDED_AMOUNT: u64 = 1_000_000;

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -44,7 +44,7 @@ use casper_types::{
         auction::{self, DelegationRate},
         handle_payment, mint, AUCTION,
     },
-    AsymmetricType, EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
+    EraId, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const SYSTEM_CONTRACT_HASHES_NAME: &str = "system_contract_hashes.wasm";

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -2,7 +2,7 @@ use num::Zero;
 use once_cell::sync::Lazy;
 
 use casper_execution_engine::shared::motes::Motes;
-use casper_types::{system::auction::DelegationRate, AsymmetricType, PublicKey, SecretKey, U512};
+use casper_types::{system::auction::DelegationRate, PublicKey, SecretKey, U512};
 
 use crate::{
     types::{

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -7,7 +7,7 @@ use rand::{prelude::SliceRandom, Rng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smallvec::smallvec;
 
-use casper_types::{AsymmetricType, EraId, ExecutionResult, ProtocolVersion, PublicKey, SecretKey};
+use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, SecretKey};
 
 use super::{Config, Storage};
 use crate::{

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -99,10 +99,15 @@ mod tests {
     type OpenSSLSecretKey = PKey<Private>;
     type OpenSSLPublicKey = PKey<Public>;
 
+    // `SecretKey` does not implement `PartialEq`, so just compare derived `PublicKey`s.
+    fn assert_secret_keys_equal(lhs: &SecretKey, rhs: &SecretKey) {
+        assert_eq!(PublicKey::from(lhs), PublicKey::from(rhs));
+    }
+
     fn secret_key_der_roundtrip(secret_key: SecretKey) {
         let der_encoded = secret_key.to_der().unwrap();
         let decoded = SecretKey::from_der(&der_encoded).unwrap();
-        assert_eq!(secret_key, decoded);
+        assert_secret_keys_equal(&secret_key, &decoded);
         assert_eq!(secret_key.tag(), decoded.tag());
 
         // Ensure malformed encoded version fails to decode.
@@ -112,7 +117,7 @@ mod tests {
     fn secret_key_pem_roundtrip(secret_key: SecretKey) {
         let pem_encoded = secret_key.to_pem().unwrap();
         let decoded = SecretKey::from_pem(pem_encoded.as_bytes()).unwrap();
-        assert_eq!(secret_key, decoded);
+        assert_secret_keys_equal(&secret_key, &decoded);
         assert_eq!(secret_key.tag(), decoded.tag());
 
         // Check PEM-encoded can be decoded by openssl.
@@ -124,7 +129,7 @@ mod tests {
 
     fn known_secret_key_to_pem(expected_key: &SecretKey, known_key_pem: &str, expected_tag: u8) {
         let decoded = SecretKey::from_pem(known_key_pem.as_bytes()).unwrap();
-        assert_eq!(*expected_key, decoded);
+        assert_secret_keys_equal(expected_key, &decoded);
         assert_eq!(expected_tag, decoded.tag());
     }
 
@@ -134,7 +139,7 @@ mod tests {
 
         secret_key.to_file(&path).unwrap();
         let decoded = SecretKey::from_file(&path).unwrap();
-        assert_eq!(secret_key, decoded);
+        assert_secret_keys_equal(&secret_key, &decoded);
         assert_eq!(secret_key.tag(), decoded.tag());
     }
 

--- a/node/src/crypto/asymmetric_key_ext.rs
+++ b/node/src/crypto/asymmetric_key_ext.rs
@@ -92,20 +92,14 @@ pub trait AsymmetricKeyExt: Sized {
 impl AsymmetricKeyExt for SecretKey {
     fn generate_ed25519() -> Result<Self, Error> {
         let mut bytes = [0u8; Self::ED25519_LENGTH];
-        if getrandom::getrandom(&mut bytes[..]).is_ok() {
-            SecretKey::ed25519_from_bytes(bytes).map_err(Error::from)
-        } else {
-            Err(Error::RNGFailure)
-        }
+        getrandom::getrandom(&mut bytes[..])?;
+        Ok(SecretKey::ed25519_from_bytes(bytes)?)
     }
 
     fn generate_secp256k1() -> Result<Self, Error> {
         let mut bytes = [0u8; Self::SECP256K1_LENGTH];
-        if getrandom::getrandom(&mut bytes[..]).is_ok() {
-            SecretKey::secp256k1_from_bytes(bytes).map_err(Error::from)
-        } else {
-            Err(Error::RNGFailure)
-        }
+        getrandom::getrandom(&mut bytes[..])?;
+        Ok(SecretKey::secp256k1_from_bytes(bytes)?)
     }
 
     fn to_file<P: AsRef<Path>>(&self, file: P) -> Result<(), Error> {

--- a/node/src/crypto/error.rs
+++ b/node/src/crypto/error.rs
@@ -55,13 +55,13 @@ pub enum Error {
     #[error("invalid operation on system key: {0}")]
     System(String),
 
-    /// Error related to the underlying signature crate
-    #[error("Error in signature")]
+    /// Error related to the underlying signature crate.
+    #[error("error in signature")]
     Signature(SignatureError),
 
-    /// Error in generating random seed for cryptographic operations.
-    #[error("Failure in the generation of a random seed")]
-    RNGFailure,
+    /// Error in getting random bytes from the system's preferred random number source.
+    #[error("failed to get random bytes: {0}")]
+    GetRandomBytes(#[from] getrandom::Error),
 }
 
 impl From<PemError> for Error {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 use casper_types::system::auction::BLOCK_REWARD;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    AsymmetricType, EraId, ProtocolVersion, PublicKey, SecretKey, Signature, U512,
+    EraId, ProtocolVersion, PublicKey, SecretKey, Signature, U512,
 };
 
 use super::{Item, Tag, Timestamp};

--- a/node/src/types/chainspec/accounts_config/account_config.rs
+++ b/node/src/types/chainspec/accounts_config/account_config.rs
@@ -10,7 +10,7 @@ use casper_types::{
     PublicKey,
 };
 #[cfg(test)]
-use casper_types::{AsymmetricType, SecretKey, U512};
+use casper_types::{SecretKey, U512};
 
 #[cfg(test)]
 use crate::testing::TestRng;

--- a/node/src/types/chainspec/accounts_config/delegator_config.rs
+++ b/node/src/types/chainspec/accounts_config/delegator_config.rs
@@ -9,7 +9,7 @@ use casper_types::{
     PublicKey,
 };
 #[cfg(test)]
-use casper_types::{AsymmetricType, SecretKey, U512};
+use casper_types::{SecretKey, U512};
 
 #[cfg(test)]
 use crate::testing::TestRng;

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::{
     system::auction::{Bid, Bids, DelegationRate, Delegator, EraValidators},
-    AccessRights, AsymmetricType, EraId, PublicKey, SecretKey, URef, U512,
+    AccessRights, EraId, PublicKey, SecretKey, URef, U512,
 };
 
 use crate::{crypto::hash::Digest, rpcs::docs::DocExample};

--- a/smart_contracts/contracts/test/ee-597-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-597-regression/src/main.rs
@@ -7,7 +7,7 @@ use casper_contract::contract_api::{runtime, system};
 use casper_types::{
     runtime_args,
     system::auction::{self, DelegationRate},
-    AsymmetricType, ContractHash, PublicKey, RuntimeArgs, SecretKey, U512,
+    ContractHash, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const DELEGATION_RATE: DelegationRate = 42;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -16,8 +16,8 @@ base64 = { version = "0.13.0", default-features = false }
 bitflags = "1"
 blake2 = { version = "0.9.0", default-features = false }
 datasize = { version = "0.2.4", default-features = false }
+displaydoc = { version = "0.1", default-features = false, optional = true }
 ed25519-dalek = { version = "1.0.0", default-features = false, features = ["rand", "u64_backend"] }
-thiserror = { version = "1.0.20", default-features = false, optional = true }
 hex = { version = "0.4.2", default-features = false }
 hex_fmt = "0.3.0"
 k256 = { version = "0.7.2", default-features = false, features = ["ecdsa", "zeroize"] }
@@ -25,14 +25,14 @@ num-derive = { version = "0.3.0", default-features = false }
 num-integer = { version = "0.1.42", default-features = false }
 num-rational = { version = "0.4.0", default-features = false }
 num-traits = { version = "0.2.10", default-features = false }
+once_cell = "1.5.2"
 proptest = { version = "1.0.0", optional = true }
 rand = { version = "0.8.3", default-features = false, features = ["small_rng"] }
 schemars = { version = "0.8.0", features = ["preserve_order"], optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
+thiserror = { version = "1.0.20", default-features = false, optional = true }
 uint = { version = "0.9.0", default-features = false }
-once_cell = "1.5.2"
-displaydoc = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1.3.1"
@@ -40,8 +40,8 @@ criterion = "0.3.3"
 getrandom = { version = "0.2.0", features = ["rdrand"] }
 proptest = "1.0.0"
 serde_json = "1.0.55"
-version-sync = "0.9"
 serde_test = "1.0.117"
+version-sync = "0.9"
 
 [features]
 default = ["base16/alloc", "hex/alloc", "serde/alloc", "serde_json/alloc", "displaydoc"]

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -267,7 +267,7 @@ impl AccountHash {
             PublicKey::Ed25519(_) => ED25519_LOWERCASE,
             PublicKey::Secp256k1(_) => SECP256K1_LOWERCASE,
         };
-        let public_key_bytes: Vec<u8> = public_key.clone().into();
+        let public_key_bytes: Vec<u8> = public_key.into();
 
         // Prepare preimage based on the public key parameters.
         let preimage = {

--- a/types/src/cl_value.rs
+++ b/types/src/cl_value.rs
@@ -281,7 +281,7 @@ mod tests {
 
     mod simple_types {
         use super::*;
-        use crate::{crypto::SecretKey, AsymmetricType};
+        use crate::crypto::SecretKey;
 
         #[test]
         fn bool_cl_value_should_encode_to_json() {
@@ -435,7 +435,7 @@ mod tests {
 
     mod option {
         use super::*;
-        use crate::{crypto::SecretKey, AsymmetricType};
+        use crate::crypto::SecretKey;
 
         #[test]
         fn bool_cl_value_should_encode_to_json() {
@@ -670,7 +670,7 @@ mod tests {
 
     mod result {
         use super::*;
-        use crate::{crypto::SecretKey, AsymmetricType};
+        use crate::crypto::SecretKey;
 
         #[test]
         fn bool_cl_value_should_encode_to_json() {

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -208,26 +208,6 @@ impl Tagged<u8> for SecretKey {
     }
 }
 
-// TODO - this should be feature-gated for use in the casper-node tests only.
-#[doc(hidden)]
-impl PartialEq for SecretKey {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SecretKey::System, SecretKey::System) => true,
-            (SecretKey::Ed25519(lhs), SecretKey::Ed25519(rhs)) => lhs.as_ref() == rhs.as_ref(),
-            (SecretKey::Secp256k1(lhs), SecretKey::Secp256k1(rhs)) => {
-                let mut lhs_secret_bytes = Secp256k1SecretBytes::from(lhs.to_bytes());
-                let mut rhs_secret_bytes = Secp256k1SecretBytes::from(rhs.to_bytes());
-                let result = *lhs_secret_bytes == *rhs_secret_bytes;
-                lhs_secret_bytes.zeroize();
-                rhs_secret_bytes.zeroize();
-                result
-            }
-            _ => false,
-        }
-    }
-}
-
 /// A public asymmetric key.
 #[derive(DataSize, Eq, PartialEq)]
 pub enum PublicKey {

--- a/types/src/crypto/asymmetric_key.rs
+++ b/types/src/crypto/asymmetric_key.rs
@@ -7,7 +7,7 @@ use alloc::{
 };
 use core::{
     cmp::Ordering,
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
     hash::{Hash, Hasher},
     iter,
@@ -20,11 +20,14 @@ use ed25519_dalek::{
     SECRET_KEY_LENGTH as ED25519_SECRET_KEY_LENGTH, SIGNATURE_LENGTH as ED25519_SIGNATURE_LENGTH,
 };
 use hex_fmt::HexFmt;
-use k256::ecdsa::{
-    Signature as Secp256k1Signature, SigningKey as Secp256k1SecretKey,
-    VerifyingKey as Secp256k1PublicKey,
+use k256::{
+    ecdsa::{
+        Signature as Secp256k1Signature, SigningKey as Secp256k1SecretKey,
+        VerifyingKey as Secp256k1PublicKey,
+    },
+    elliptic_curve::zeroize::Zeroize,
+    SecretBytes as Secp256k1SecretBytes,
 };
-
 #[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -44,15 +47,15 @@ mod tests;
 
 const TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
 
-/// Tag for system variant
+/// Tag for system variant.
 pub const SYSTEM_TAG: u8 = 0;
 const SYSTEM: &str = "System";
 
-/// Tag for ed25519 variant
+/// Tag for ed25519 variant.
 pub const ED25519_TAG: u8 = 1;
 const ED25519: &str = "Ed25519";
 
-/// Tag for secp256k1 variant
+/// Tag for secp256k1 variant.
 pub const SECP256K1_TAG: u8 = 2;
 const SECP256K1: &str = "Secp256k1";
 
@@ -60,21 +63,25 @@ const SECP256K1_SECRET_KEY_LENGTH: usize = 32;
 const SECP256K1_COMPRESSED_PUBLIC_KEY_LENGTH: usize = 33;
 const SECP256K1_SIGNATURE_LENGTH: usize = 64;
 
-/// Public key for system account
+/// Public key for system account.
 pub const SYSTEM_ACCOUNT: PublicKey = PublicKey::System;
 
-/// Operations on asymmetric cryptographic type
-pub trait AsymmetricType: Sized + Into<Vec<u8>> + Tagged<u8> + Clone {
-    /// Converts the signature to hex, where the first byte represents the algorithm tag.
-    fn to_hex(&self) -> String {
+/// Operations on asymmetric cryptographic type.
+pub trait AsymmetricType<'a>
+where
+    Self: 'a + Sized + Tagged<u8>,
+    &'a Self: Into<Vec<u8>>,
+{
+    /// Converts `self` to hex, where the first byte represents the algorithm tag.
+    fn to_hex(&'a self) -> String {
         let bytes = iter::once(self.tag())
-            .chain(Into::<Vec<u8>>::into(self.clone()))
+            .chain(self.into())
             .collect::<Vec<u8>>();
         hex::encode(bytes)
     }
 
-    /// Tries to decode a signature from its hex-representation.  The hex format should be as
-    /// produced by `Signature::to_hex()`.
+    /// Tries to decode `Self` from its hex-representation.  The hex format should be as produced
+    /// by `AsymmetricType::to_hex()`.
     fn from_hex<A: AsRef<[u8]>>(input: A) -> Result<Self, Error> {
         if input.as_ref().len() < 2 {
             return Err(Error::AsymmetricKey("too short".to_string()));
@@ -133,6 +140,25 @@ impl SecretKey {
     /// The length in bytes of a secp256k1 secret key.
     pub const SECP256K1_LENGTH: usize = SECP256K1_SECRET_KEY_LENGTH;
 
+    /// Constructs a new system variant.
+    pub fn system() -> Self {
+        SecretKey::System
+    }
+
+    /// Constructs a new ed25519 variant from a byte slice.
+    pub fn ed25519_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Error> {
+        Ok(SecretKey::Ed25519(ed25519_dalek::SecretKey::from_bytes(
+            bytes.as_ref(),
+        )?))
+    }
+
+    /// Constructs a new secp256k1 variant from a byte slice.
+    pub fn secp256k1_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Error> {
+        Ok(SecretKey::Secp256k1(Secp256k1SecretKey::from_bytes(
+            bytes.as_ref(),
+        )?))
+    }
+
     fn variant_name(&self) -> &str {
         match self {
             SecretKey::System => SYSTEM,
@@ -142,49 +168,19 @@ impl SecretKey {
     }
 }
 
-impl AsymmetricType for SecretKey {
-    fn system() -> Self {
-        SecretKey::System
-    }
-
-    fn ed25519_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Error> {
-        Ok(SecretKey::Ed25519(ed25519_dalek::SecretKey::from_bytes(
-            bytes.as_ref(),
-        )?))
-    }
-
-    fn secp256k1_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Error> {
-        Ok(SecretKey::Secp256k1(Secp256k1SecretKey::from_bytes(
-            bytes.as_ref(),
-        )?))
-    }
-}
-
-impl From<SecretKey> for Vec<u8> {
-    fn from(secret_key: SecretKey) -> Vec<u8> {
-        Vec::<u8>::from(&secret_key)
-    }
-}
-
-impl From<&SecretKey> for Vec<u8> {
-    fn from(secret_key: &SecretKey) -> Self {
-        match secret_key {
-            SecretKey::System => Vec::new(),
-            SecretKey::Ed25519(key) => key.as_ref().into(),
-            SecretKey::Secp256k1(key) => key.to_bytes().as_slice().into(),
-        }
-    }
-}
-
 impl Clone for SecretKey {
     fn clone(&self) -> Self {
         match self {
             SecretKey::System => SecretKey::System,
-            SecretKey::Ed25519(sk) => Self::ed25519_from_bytes(*sk.as_bytes()).unwrap(),
-            SecretKey::Secp256k1(sk) => {
-                let raw_bytes: [u8; SECP256K1_SECRET_KEY_LENGTH] =
-                    sk.to_bytes().as_slice().try_into().unwrap();
-                Self::secp256k1_from_bytes(&raw_bytes).unwrap()
+            SecretKey::Ed25519(secret_key) => {
+                Self::ed25519_from_bytes(*secret_key.as_bytes()).unwrap()
+            }
+            SecretKey::Secp256k1(secret_key) => {
+                // Use `Secp256k1SecretBytes` to ensure the raw bytes are zeroized after use.
+                let mut secret_bytes = Secp256k1SecretBytes::from(secret_key.to_bytes());
+                let secret_key = Self::secp256k1_from_bytes(secret_bytes.as_ref()).unwrap();
+                secret_bytes.zeroize();
+                secret_key
             }
         }
     }
@@ -192,23 +188,13 @@ impl Clone for SecretKey {
 
 impl Debug for SecretKey {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "SecretKey::{}({})",
-            self.variant_name(),
-            HexFmt(Into::<Vec<u8>>::into(self.clone()))
-        )
+        write!(formatter, "SecretKey::{}", self.variant_name())
     }
 }
 
 impl Display for SecretKey {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "SecKey::{}({:10})",
-            self.variant_name(),
-            HexFmt(Into::<Vec<u8>>::into(self.clone()))
-        )
+        <Self as Debug>::fmt(self, formatter)
     }
 }
 
@@ -222,67 +208,23 @@ impl Tagged<u8> for SecretKey {
     }
 }
 
-impl ToBytes for SecretKey {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        match self {
-            SecretKey::System => buffer.insert(0, SYSTEM_TAG),
-            SecretKey::Ed25519(secret_key) => {
-                buffer.insert(0, ED25519_TAG);
-                let ed25519_bytes = secret_key.as_bytes();
-                buffer.extend_from_slice(ed25519_bytes);
+// TODO - this should be feature-gated for use in the casper-node tests only.
+#[doc(hidden)]
+impl PartialEq for SecretKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SecretKey::System, SecretKey::System) => true,
+            (SecretKey::Ed25519(lhs), SecretKey::Ed25519(rhs)) => lhs.as_ref() == rhs.as_ref(),
+            (SecretKey::Secp256k1(lhs), SecretKey::Secp256k1(rhs)) => {
+                let mut lhs_secret_bytes = Secp256k1SecretBytes::from(lhs.to_bytes());
+                let mut rhs_secret_bytes = Secp256k1SecretBytes::from(rhs.to_bytes());
+                let result = *lhs_secret_bytes == *rhs_secret_bytes;
+                lhs_secret_bytes.zeroize();
+                rhs_secret_bytes.zeroize();
+                result
             }
-            SecretKey::Secp256k1(secret_key) => {
-                buffer.insert(0, SECP256K1_TAG);
-                buffer.extend_from_slice(secret_key.to_bytes().as_slice());
-            }
+            _ => false,
         }
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        TAG_LENGTH
-            + match self {
-                SecretKey::System => Self::SYSTEM_LENGTH,
-                SecretKey::Ed25519(_) => Self::ED25519_LENGTH,
-                SecretKey::Secp256k1(_) => Self::SECP256K1_LENGTH,
-            }
-    }
-}
-
-impl FromBytes for SecretKey {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (tag, remainder) = u8::from_bytes(bytes)?;
-        match tag {
-            SYSTEM_TAG => Ok((SecretKey::System, remainder)),
-            ED25519_TAG => {
-                let (raw_bytes, remainder): ([u8; Self::ED25519_LENGTH], _) =
-                    FromBytes::from_bytes(remainder)?;
-                let secret_key = Self::ed25519_from_bytes(raw_bytes)
-                    .map_err(|_| bytesrepr::Error::Formatting)?;
-                Ok((secret_key, remainder))
-            }
-            SECP256K1_TAG => {
-                let (raw_bytes, remainder): ([u8; Self::SECP256K1_LENGTH], _) =
-                    FromBytes::from_bytes(remainder)?;
-                let secret_key = Self::secp256k1_from_bytes(raw_bytes)
-                    .map_err(|_| bytesrepr::Error::Formatting)?;
-                Ok((secret_key, remainder))
-            }
-            _ => Err(bytesrepr::Error::Formatting),
-        }
-    }
-}
-
-impl Serialize for SecretKey {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        detail::serialize(self, serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for SecretKey {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        detail::deserialize(deserializer)
     }
 }
 
@@ -323,7 +265,7 @@ impl PublicKey {
     }
 }
 
-impl AsymmetricType for PublicKey {
+impl AsymmetricType<'_> for PublicKey {
     fn system() -> Self {
         PublicKey::System
     }
@@ -591,7 +533,7 @@ impl Signature {
     }
 }
 
-impl AsymmetricType for Signature {
+impl AsymmetricType<'_> for Signature {
     fn system() -> Self {
         Signature::System
     }
@@ -786,7 +728,7 @@ mod detail {
 
     use serde::{de::Error as _deError, Deserialize, Deserializer, Serialize, Serializer};
 
-    use super::{PublicKey, SecretKey, Signature};
+    use super::{PublicKey, Signature};
     use crate::AsymmetricType;
 
     /// Used to serialize and deserialize asymmetric key types where the (de)serializer is not a
@@ -798,16 +740,6 @@ mod detail {
         System,
         Ed25519(Vec<u8>),
         Secp256k1(Vec<u8>),
-    }
-
-    impl From<&SecretKey> for AsymmetricTypeAsBytes {
-        fn from(secret_key: &SecretKey) -> Self {
-            match secret_key {
-                SecretKey::System => AsymmetricTypeAsBytes::System,
-                key @ SecretKey::Ed25519(_) => AsymmetricTypeAsBytes::Ed25519(key.into()),
-                key @ SecretKey::Secp256k1(_) => AsymmetricTypeAsBytes::Secp256k1(key.into()),
-            }
-        }
     }
 
     impl From<&PublicKey> for AsymmetricTypeAsBytes {
@@ -832,7 +764,8 @@ mod detail {
 
     pub fn serialize<'a, T, S>(value: &'a T, serializer: S) -> Result<S::Ok, S::Error>
     where
-        T: AsymmetricType,
+        T: AsymmetricType<'a>,
+        Vec<u8>: From<&'a T>,
         S: Serializer,
         AsymmetricTypeAsBytes: From<&'a T>,
     {
@@ -843,9 +776,10 @@ mod detail {
         AsymmetricTypeAsBytes::from(value).serialize(serializer)
     }
 
-    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    pub fn deserialize<'a, 'de, T, D>(deserializer: D) -> Result<T, D::Error>
     where
-        T: AsymmetricType,
+        T: AsymmetricType<'a>,
+        Vec<u8>: From<&'a T>,
         D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {

--- a/types/src/crypto/asymmetric_key/gens.rs
+++ b/types/src/crypto/asymmetric_key/gens.rs
@@ -8,7 +8,7 @@ use proptest::{
     prop_oneof,
 };
 
-use crate::{crypto::SecretKey, AsymmetricType, PublicKey};
+use crate::{crypto::SecretKey, PublicKey};
 
 /// Creates an arbitrary [`SecretKey`]
 pub fn secret_key_arb() -> impl Strategy<Value = SecretKey> {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -704,6 +704,8 @@ impl<'de> Deserialize<'de> for Key {
 
 #[cfg(test)]
 mod tests {
+    use std::string::ToString;
+
     use proptest::proptest;
 
     use super::*;

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -308,7 +308,7 @@ mod tests {
     use crate::{
         bytesrepr,
         system::auction::{bid::VestingSchedule, Bid, DelegationRate, Delegator},
-        AccessRights, AsymmetricType, PublicKey, SecretKey, URef, U512,
+        AccessRights, PublicKey, SecretKey, URef, U512,
     };
 
     #[test]

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -190,8 +190,7 @@ impl FromBytes for Delegator {
 #[cfg(test)]
 mod tests {
     use crate::{
-        bytesrepr, system::auction::Delegator, AccessRights, AsymmetricType, PublicKey, SecretKey,
-        URef, U512,
+        bytesrepr, system::auction::Delegator, AccessRights, PublicKey, SecretKey, URef, U512,
     };
 
     #[test]

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -288,7 +288,7 @@ mod tests {
             match Error::try_from(i) {
                 Ok(error) if i < MAX_ERROR_VALUE => assert_eq!(error as u8, i),
                 Ok(error) => panic!(
-                    "value of variant {} ({}) exceeds MAX_ERROR_VALUE ({})",
+                    "value of variant {:?} ({}) exceeds MAX_ERROR_VALUE ({})",
                     error, i, MAX_ERROR_VALUE
                 ),
                 Err(TryFromU8ForError(())) if i >= MAX_ERROR_VALUE => (),

--- a/types/src/system/auction/seigniorage_recipient.rs
+++ b/types/src/system/auction/seigniorage_recipient.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::{
         bytesrepr,
         system::auction::{DelegationRate, SeigniorageRecipient},
-        AsymmetricType, SecretKey, U512,
+        SecretKey, U512,
     };
 
     #[test]

--- a/types/src/system/auction/unbonding_purse.rs
+++ b/types/src/system/auction/unbonding_purse.rs
@@ -135,7 +135,7 @@ mod tests {
     use crate::{
         bytesrepr,
         system::auction::{EraId, UnbondingPurse},
-        AccessRights, AsymmetricType, PublicKey, SecretKey, URef, U512,
+        AccessRights, PublicKey, SecretKey, URef, U512,
     };
 
     const BONDING_PURSE: URef = URef::new([41; 32], AccessRights::READ_ADD_WRITE);

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -204,7 +204,7 @@ mod tests {
             match Error::try_from(i) {
                 Ok(error) if i < MAX_ERROR_VALUE => assert_eq!(error as u8, i),
                 Ok(error) => panic!(
-                    "value of variant {} ({}) exceeds MAX_ERROR_VALUE ({})",
+                    "value of variant {:?} ({}) exceeds MAX_ERROR_VALUE ({})",
                     error, i, MAX_ERROR_VALUE
                 ),
                 Err(TryFromU8ForError(())) if i >= MAX_ERROR_VALUE => (),


### PR DESCRIPTION
For improved security of the `SecretKey` type, this PR changes the following:
* removed `impl AsymmetricType for SecretKey`
* removed `impl From<SecretKey> for Vec<u8>`
* removed `impl From<*SecretKey> for Vec<u8>`
* removed `impl ToBytes for SecretKey` (and corresponding `FromBytes`)
* removed `impl Serialize for SecretKey` (and corresponding `Deserialize`)
* zeroizes temporary bytes created when cloning `SecretKey`
* avoids outputting the contents of the `SecretKey` in `Display` and `Debug` impls

By removing these impls, there remained no simple way to compare secret keys, and this functionality is required for the unit tests.  As these tests live in the `casper-node` crate rather than the `casper-types` crate, I have unfortunately added `impl PartialEq for SecretKey` to accommodate for this.  I'd like to see this either feature-gated (defaulted to off outside the context of these `casper-node` tests) or some other solution which would allow us to remove that impl.

It also improves the `AsymmetricType::to_hex` method by avoiding a needless clone of the public key/signature, and finally it improves the error story by including the actual error returned by `getrandom` in the relevant variant to help with debugging.

