### PR TITLE
Peers metric regression test

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -804,6 +804,7 @@ where
         effect_builder: EffectBuilder<REv>,
         peer_id: NodeId,
     ) -> Effects<Event<P>> {
+        trace!(num_peers = self.peers().len(), new_peer=%peer_id, "connection complete");
         self.net_metrics.peers.set(self.peers().len() as i64);
         effect_builder.announce_new_peer(peer_id).ignore()
     }


### PR DESCRIPTION
This adds a regression test for the faulty behavior of the peers metric, ensuring it eventually reaches `n-1` on small networks of `n` nodes.