### PR TITLE
Update state gen tool in preparation for protocol data migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,7 +2405,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "global-state-update-gen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base16",
  "base64",
@@ -2413,6 +2413,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-types",
  "clap",
+ "lmdb",
 ]
 
 [[package]]

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -120,11 +120,12 @@ const OS_FLAGS: EnvironmentFlags = EnvironmentFlags::empty();
 const _STORAGE_EVENT_SIZE: usize = mem::size_of::<Event>();
 const_assert!(_STORAGE_EVENT_SIZE <= 96);
 
-const LMDB_FILES: [&str; 4] = [
+const STORAGE_FILES: [&str; 5] = [
     "data.lmdb",
     "data.lmdb-lock",
     "storage.lmdb",
     "storage.lmdb-lock",
+    "sse_index",
 ];
 
 #[derive(Debug, From, Serialize)]
@@ -297,8 +298,8 @@ impl Storage {
                 .map_err(|err| Error::CreateDatabaseDirectory(network_subdir.clone(), err))?;
         }
 
-        if should_move_storage_files_to_network_subdir(&root, &LMDB_FILES)? {
-            move_storage_files_to_network_subdir(&root, &network_subdir, &LMDB_FILES)?;
+        if should_move_storage_files_to_network_subdir(&root, &STORAGE_FILES)? {
+            move_storage_files_to_network_subdir(&root, &network_subdir, &STORAGE_FILES)?;
         }
 
         root = network_subdir;

--- a/utils/global-state-update-gen/Cargo.toml
+++ b/utils/global-state-update-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "global-state-update-gen"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Bartłomiej Kamiński <bart@casperlabs.io>"]
 edition = "2018"
 
@@ -11,3 +11,4 @@ casper-engine-test-support = { path = "../../execution_engine_testing/test_suppo
 casper-execution-engine = { path = "../../execution_engine" }
 casper-types = { path = "../../types", default-features = false, features = ["std"] }
 clap = "2.33"
+lmdb = "0.8"

--- a/utils/global-state-update-gen/src/main.rs
+++ b/utils/global-state-update-gen/src/main.rs
@@ -1,11 +1,16 @@
 mod auction_utils;
 mod balances;
+mod system_contract_registry;
 mod utils;
 mod validators;
 
 use clap::{crate_version, App, Arg, SubCommand};
 
-use crate::{balances::generate_balances_update, validators::generate_validators_update};
+use crate::{
+    balances::generate_balances_update,
+    system_contract_registry::generate_system_contract_registry,
+    validators::generate_validators_update,
+};
 
 fn main() {
     let matches = App::new("Global State Update Generator")
@@ -102,11 +107,27 @@ fn main() {
                         .required(true),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("system-contract-registry")
+                .about("Generates an update creating the system contract registry")
+                .arg(
+                    Arg::with_name("data_dir")
+                        .short("d")
+                        .long("data-dir")
+                        .value_name("PATH")
+                        .help("Data storage directory containing the global state database file")
+                        .takes_value(true)
+                        .required(true),
+                ),
+        )
         .get_matches();
 
     match matches.subcommand() {
         ("validators", Some(sub_matches)) => generate_validators_update(sub_matches),
         ("balances", Some(sub_matches)) => generate_balances_update(sub_matches),
+        ("system-contract-registry", Some(sub_matches)) => {
+            generate_system_contract_registry(sub_matches)
+        }
         _ => {
             println!("Unknown subcommand.");
         }

--- a/utils/global-state-update-gen/src/system_contract_registry.rs
+++ b/utils/global-state-update-gen/src/system_contract_registry.rs
@@ -1,0 +1,97 @@
+use std::path::Path;
+
+use clap::ArgMatches;
+use lmdb::{self, Cursor, Environment, EnvironmentFlags, Transaction};
+
+use casper_execution_engine::{
+    core::engine_state::genesis::SystemContractRegistry, shared::stored_value::StoredValue,
+};
+use casper_types::{
+    bytesrepr::FromBytes,
+    system::{AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT},
+    CLValue, ContractHash, Key, KEY_HASH_LENGTH,
+};
+
+use crate::utils::print_entry;
+
+const DATABASE_NAME: &str = "PROTOCOL_DATA_STORE";
+
+pub(crate) fn generate_system_contract_registry(matches: &ArgMatches<'_>) {
+    let data_dir = Path::new(matches.value_of("data_dir").unwrap_or("."));
+    let database_path = data_dir.join("data.lmdb");
+
+    let env = Environment::new()
+        .set_flags(EnvironmentFlags::READ_ONLY | EnvironmentFlags::NO_SUB_DIR)
+        .set_max_dbs(2)
+        .open(&database_path)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to initialize database environment at {}: {}",
+                database_path.display(),
+                error
+            )
+        });
+
+    let protocol_data_db = env.open_db(Some(DATABASE_NAME)).unwrap_or_else(|error| {
+        panic!("failed to open database named {}: {}", DATABASE_NAME, error)
+    });
+
+    let ro_transaction = env
+        .begin_ro_txn()
+        .unwrap_or_else(|error| panic!("failed to initialize read-only transaction: {}", error));
+    let mut cursor = ro_transaction
+        .open_ro_cursor(protocol_data_db)
+        .unwrap_or_else(|error| panic!("failed to open a read-only cursor: {}", error));
+
+    let serialized_protocol_data = match cursor.iter().next() {
+        Some((_key, value)) => value,
+        None => {
+            println!("No protocol data found");
+            return;
+        }
+    };
+
+    // The last four 32-byte chunks of the serialized data are the contract hashes.
+    let start_index = serialized_protocol_data
+        .len()
+        .saturating_sub(4 * KEY_HASH_LENGTH);
+    let remainder = &serialized_protocol_data[start_index..];
+    let (mint_hash, remainder) = ContractHash::from_bytes(remainder).unwrap_or_else(|error| {
+        panic!(
+            "failed to parse mint hash: {:?}\nraw_bytes: {:?}",
+            error, serialized_protocol_data
+        )
+    });
+    let (handle_payment_hash, remainder) =
+        ContractHash::from_bytes(remainder).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse handle_payment hash: {:?}\nraw_bytes: {:?}",
+                error, serialized_protocol_data
+            )
+        });
+    let (standard_payment_hash, remainder) =
+        ContractHash::from_bytes(remainder).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse standard_payment hash: {:?}\nraw_bytes: {:?}",
+                error, serialized_protocol_data
+            )
+        });
+    let (auction_hash, remainder) = ContractHash::from_bytes(remainder).unwrap_or_else(|error| {
+        panic!(
+            "failed to parse auction hash: {:?}\nraw_bytes: {:?}",
+            error, serialized_protocol_data
+        )
+    });
+    assert!(remainder.is_empty());
+
+    let mut registry = SystemContractRegistry::new();
+    registry.insert(MINT.to_string(), mint_hash);
+    registry.insert(HANDLE_PAYMENT.to_string(), handle_payment_hash);
+    registry.insert(STANDARD_PAYMENT.to_string(), standard_payment_hash);
+    registry.insert(AUCTION.to_string(), auction_hash);
+
+    print_entry(
+        &Key::SystemContractRegistry,
+        &StoredValue::from(CLValue::from_t(registry).unwrap()),
+    );
+}


### PR DESCRIPTION
This updates the `global-state-update-gen` tool to convert stored protocol data to a format suitable to be used as a system contract registry in a global_state.toml file.

It also removes a check (and unit tests for that check) which assumed that providing a global_state.toml indicated an emergency upgrade.

Finally, it also fixes an issue where the sse_index file was not moved to the new storage location, causing the SSE server to restart from index 0 on upgrade.