### PR TITLE
NCTL: add global_state.toml support to upgrade scenarios

### DIFF
--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -444,8 +444,6 @@ function setup_asset_global_state_toml() {
         if [ -f "$PATH_TO_NET/nodes/node-$IDX/storage/data.lmdb" ]; then
             GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
                     system-contract-registry -d "$PATH_TO_NET"/nodes/node-"$IDX"/storage)
-
-            #echo "$GLOBAL_STATE_OUTPUT" > "$PATH_TO_NET/nodes/node-$IDX/config/$PROTOCOL_VERSION/global_state.toml"
         else
             GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
                     system-contract-registry -d "$PATH_TO_NET"/nodes/node-1/storage)

--- a/utils/nctl/sh/assets/setup_shared.sh
+++ b/utils/nctl/sh/assets/setup_shared.sh
@@ -428,6 +428,33 @@ function setup_asset_node_configs()
     done
 }
 
+function setup_asset_global_state_toml() {
+    log "... setting node global_state.toml"
+
+    local COUNT_NODES=${1}
+    local PROTOCOL_VERSION=${2}
+    local IDX
+    local GLOBAL_STATE_OUTPUT
+    local PATH_TO_NET
+
+    PATH_TO_NET="$(get_path_to_net)"
+
+    for IDX in $(seq 1 "$COUNT_NODES")
+    do
+        if [ -f "$PATH_TO_NET/nodes/node-$IDX/storage/data.lmdb" ]; then
+            GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
+                    system-contract-registry -d "$PATH_TO_NET"/nodes/node-"$IDX"/storage)
+
+            #echo "$GLOBAL_STATE_OUTPUT" > "$PATH_TO_NET/nodes/node-$IDX/config/$PROTOCOL_VERSION/global_state.toml"
+        else
+            GLOBAL_STATE_OUTPUT=$("$NCTL_CASPER_HOME"/target/"$NCTL_COMPILE_TARGET"/global-state-update-gen \
+                    system-contract-registry -d "$PATH_TO_NET"/nodes/node-1/storage)
+        fi
+
+        echo "$GLOBAL_STATE_OUTPUT" > "$PATH_TO_NET/nodes/node-$IDX/config/$PROTOCOL_VERSION/global_state.toml"
+    done
+}
+
 #######################################
 # Sets node configuration file workaround related to 'unit_hashes_folder' setting change.
 # Arguments:

--- a/utils/nctl/sh/assets/upgrade_from_stage.sh
+++ b/utils/nctl/sh/assets/upgrade_from_stage.sh
@@ -103,6 +103,8 @@ function _main()
                                  "$PROTOCOL_VERSION" \
                                  "$PATH_TO_STAGE/$PROTOCOL_VERSION/config.toml" \
                                  false
+        setup_asset_global_state_toml "$COUNT_NODES" \
+                                      "$PROTOCOL_VERSION"
         sleep 10.0
     else
         log "ATTENTION :: no more staged upgrades to rollout !!!"


### PR DESCRIPTION
Changes:
- Adds support for generating `global_state.toml` from lmdb files.

Issue: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/53