### PR TITLE
Cleanups relating to get-validator-changes

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * RPM package build and publish.
-* New client binary command `get-validator-changes` that returns changes in validator status between two eras.
+* New client binary command `get-validator-changes` that returns status changes of active validators.
 
 ### Changed
 * Support building and testing using stable Rust.

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -749,9 +749,9 @@ pub extern "C" fn casper_get_auction_info(
     })
 }
 
-/// Retrieves changes in validator status between two eras.
+/// Retrieves status changes of active validators.
 ///
-/// See [super::get_validator_changes](super::get_validator_changes) for more details.
+/// See [get_validator_changes](super::get_validator_changes) for more details.
 #[no_mangle]
 pub extern "C" fn casper_get_validator_changes(
     maybe_rpc_id: *const c_char,

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -618,7 +618,7 @@ pub async fn get_dictionary_item(
         .await
 }
 
-/// Retrieves changes in validator status between two eras.
+/// Retrieves status changes of active validators.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
 ///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a

--- a/client/src/get_validator_changes.rs
+++ b/client/src/get_validator_changes.rs
@@ -8,7 +8,7 @@ use casper_node::rpcs::info::GetValidatorChanges;
 
 use crate::{command::ClientCommand, common, Success};
 
-/// This struct defines the order in which the args are shown for this subcommand's help message.
+/// This enum defines the order in which the args are shown for this subcommand's help message.
 enum DisplayOrder {
     Verbose,
     NodeAddress,

--- a/client/src/get_validator_changes.rs
+++ b/client/src/get_validator_changes.rs
@@ -18,7 +18,7 @@ enum DisplayOrder {
 #[async_trait]
 impl<'a, 'b> ClientCommand<'a, 'b> for GetValidatorChanges {
     const NAME: &'static str = "get-validator-changes";
-    const ABOUT: &'static str = "Retrieves changes in validator status between two eras.";
+    const ABOUT: &'static str = "Retrieves status changes of active validators";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -55,7 +55,7 @@ enum DisplayOrder {
     GetAccountInfo,
     GetEraInfo,
     GetAuctionInfo,
-    GetValidatorInfo,
+    GetValidatorChanges,
     Keygen,
     GenerateCompletion,
     GetRpcs,
@@ -88,7 +88,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         ))
         .subcommand(GetAuctionInfo::build(DisplayOrder::GetAuctionInfo as usize))
         .subcommand(GetValidatorChanges::build(
-            DisplayOrder::GetValidatorInfo as usize,
+            DisplayOrder::GetValidatorChanges as usize,
         ))
         .subcommand(Keygen::build(DisplayOrder::Keygen as usize))
         .subcommand(GenerateCompletion::build(

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -17,13 +17,12 @@ All notable changes to this project will be documented in this file.  The format
 * Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
 * Add `contract_runtime_execute_block` histogram tracking execution time of a whole block.
 * Long-running events now log their event type.
-* Individual weights for traffic throttling can now be set through the configuration value
-  `network.estimator_weights`.
+* Individual weights for traffic throttling can now be set through the configuration value `network.estimator_weights`.
 * Add `consensus.highway.max_request_batch_size` configuration parameter. Defaults to 20.
 * New histogram metrics `deploy_acceptor_accepted_deploy` and `deploy_acceptor_rejected_deploy` that track how long the initial verification took.
 * Add gzip content negotiation (using accept-encoding header) to rpc endpoints.
 * Add `state_get_trie` JSON-RPC endpoint.
-* Add `info-get-validator-changes` JSON-RPC endpoint and REST endpoint `validator-changes`  that return the changes in validator status between two eras.
+* Add `info_get_validator_changes` JSON-RPC endpoint and REST endpoint `validator-changes`  that return the status changes of active validators.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.  The format
 * New histogram metrics `deploy_acceptor_accepted_deploy` and `deploy_acceptor_rejected_deploy` that track how long the initial verification took.
 * Add gzip content negotiation (using accept-encoding header) to rpc endpoints.
 * Add `state_get_trie` JSON-RPC endpoint.
-* Add `info_get_validator_changes` JSON-RPC endpoint and REST endpoint `validator-changes`  that return the status changes of active validators.
+* Add `info_get_validator_changes` JSON-RPC endpoint and REST endpoint `validator-changes` that return the status changes of active validators.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -39,6 +39,7 @@ use crate::{
         },
         metrics::ConsensusMetrics,
         traits::NodeIdT,
+        validator_change::ValidatorChanges,
         ActionId, Config, ConsensusMessage, Event, NewBlockPayload, ReactorEventT, ResolveValidity,
         TimerId, ValidatorChange,
     },
@@ -232,13 +233,13 @@ where
         }
     }
 
-    /// Returns a list of validator status changes, by public key.
+    /// Returns a list of status changes of active validators.
     pub(super) fn get_validator_changes(
         &self,
     ) -> BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>> {
         let mut result: BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>> = BTreeMap::new();
         for ((_, era0), (era_id, era1)) in self.active_eras.iter().tuple_windows() {
-            for (pub_key, change) in ValidatorChange::era_changes(era0, era1) {
+            for (pub_key, change) in ValidatorChanges::new(era0, era1).0 {
                 result.entry(pub_key).or_default().push((*era_id, change));
             }
         }

--- a/node/src/components/consensus/validator_change.rs
+++ b/node/src/components/consensus/validator_change.rs
@@ -1,14 +1,14 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use casper_types::{PublicKey, U512};
+use casper_types::PublicKey;
 
 use super::era_supervisor::Era;
 
 /// A change to a validator's status between two eras.
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ValidatorChange {
     /// The validator got newly added to the validator set.
     Added,
@@ -22,50 +22,76 @@ pub enum ValidatorChange {
     SeenAsFaulty,
 }
 
-impl ValidatorChange {
-    pub(super) fn era_changes<I>(
-        era0: &Era<I>,
-        era1: &Era<I>,
-    ) -> Vec<(PublicKey, ValidatorChange)> {
+pub(super) struct ValidatorChanges(pub(super) Vec<(PublicKey, ValidatorChange)>);
+
+impl ValidatorChanges {
+    pub(super) fn new<I>(era0: &Era<I>, era1: &Era<I>) -> Self {
         let era0_metadata = EraMetadata::from(era0);
         let era1_metadata = EraMetadata::from(era1);
-        Self::validator_changes(era0_metadata, era1_metadata)
+        ValidatorChanges(Self::new_from_metadata(era0_metadata, era1_metadata))
     }
 
-    fn validator_changes(
+    fn new_from_metadata(
         era0_metadata: EraMetadata,
         era1_metadata: EraMetadata,
     ) -> Vec<(PublicKey, ValidatorChange)> {
-        let mut changes = Vec::new();
-        for pub_key in era0_metadata.validators.keys() {
-            if !era1_metadata.validators.contains_key(pub_key) {
-                changes.push((pub_key.clone(), ValidatorChange::Removed));
-            }
-        }
-        for pub_key in era1_metadata.seen_as_faulty {
-            changes.push((pub_key.clone(), ValidatorChange::SeenAsFaulty));
-        }
-        for pub_key in era1_metadata.validators.keys() {
-            if !era0_metadata.validators.contains_key(pub_key) {
-                changes.push((pub_key.clone(), ValidatorChange::Added));
-            }
-            if era1_metadata.faulty.contains(pub_key) && !era0_metadata.faulty.contains(pub_key) {
-                changes.push((pub_key.clone(), ValidatorChange::Banned));
-            }
-            if era1_metadata.cannot_propose.contains(pub_key)
-                && !era0_metadata.cannot_propose.contains(pub_key)
-            {
-                changes.push((pub_key.clone(), ValidatorChange::CannotPropose));
-            }
-        }
-        changes
+        // Validators in `era0` but not `era1` are labelled `Removed`.
+        let removed_iter = era0_metadata
+            .validators
+            .difference(&era1_metadata.validators)
+            .map(|&public_key| (public_key.clone(), ValidatorChange::Removed));
+
+        // Validators in `era1` but not `era0` are labelled `Added`.
+        let added_iter = era1_metadata
+            .validators
+            .difference(&era0_metadata.validators)
+            .map(|&public_key| (public_key.clone(), ValidatorChange::Added));
+
+        // Only those seen as faulty in `era1` are labelled `SeenAsFaulty`.
+        let faulty_iter = era1_metadata
+            .seen_as_faulty
+            .iter()
+            .map(|&public_key| (public_key.clone(), ValidatorChange::SeenAsFaulty));
+
+        // Faulty peers in `era1` but not `era0` which are also validators in `era1` are labelled
+        // `Banned`.
+        let banned_iter = era1_metadata
+            .faulty
+            .difference(era0_metadata.faulty)
+            .filter_map(|public_key| {
+                if era1_metadata.validators.contains(public_key) {
+                    Some((public_key.clone(), ValidatorChange::Banned))
+                } else {
+                    None
+                }
+            });
+
+        // Peers which cannot propose in `era1` but can in `era0` and which are also validators in
+        // `era1` are labelled `CannotPropose`.
+        let cannot_propose_iter = era1_metadata
+            .cannot_propose
+            .difference(era0_metadata.cannot_propose)
+            .filter_map(|public_key| {
+                if era1_metadata.validators.contains(public_key) {
+                    Some((public_key.clone(), ValidatorChange::CannotPropose))
+                } else {
+                    None
+                }
+            });
+
+        removed_iter
+            .chain(faulty_iter)
+            .chain(added_iter)
+            .chain(banned_iter)
+            .chain(cannot_propose_iter)
+            .collect()
     }
 }
 
 #[derive(Clone)]
 struct EraMetadata<'a> {
-    validators: &'a BTreeMap<PublicKey, U512>,
-    seen_as_faulty: Vec<PublicKey>,
+    validators: HashSet<&'a PublicKey>,
+    seen_as_faulty: Vec<&'a PublicKey>,
     faulty: &'a HashSet<PublicKey>,
     cannot_propose: &'a HashSet<PublicKey>,
 }
@@ -76,10 +102,9 @@ impl<'a, I> From<&'a Era<I>> for EraMetadata<'a> {
             .consensus
             .validators_with_evidence()
             .into_iter()
-            .cloned()
             .collect();
 
-        let validators = era.validators();
+        let validators = era.validators().keys().collect();
         let faulty = &era.faulty;
         let cannot_propose = &era.cannot_propose;
         Self {
@@ -93,152 +118,233 @@ impl<'a, I> From<&'a Era<I>> for EraMetadata<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use super::*;
     use crate::{crypto::AsymmetricKeyExt, testing::TestRng};
 
-    fn preset_validators(rng: &mut TestRng) -> BTreeMap<PublicKey, U512> {
-        let mut validators = BTreeMap::new();
-        for i in 0..5 {
-            validators.insert(PublicKey::random(rng), U512::from(i));
-        }
-        validators
+    fn preset_validators(rng: &mut TestRng) -> HashSet<PublicKey> {
+        iter::repeat_with(|| PublicKey::random(rng))
+            .take(5)
+            .collect()
     }
 
     #[test]
-    fn should_report_added_status_change() {
+    fn should_report_added() {
         let mut rng = crate::new_rng();
         let validators = preset_validators(&mut rng);
+
         let era0_metadata = EraMetadata {
-            validators: &validators,
-            seen_as_faulty: vec![],
-            faulty: &Default::default(),
-            cannot_propose: &Default::default(),
-        };
-        // First, assert that adding a validator is being reported.
-        let new_validator = PublicKey::random(&mut rng);
-        let mut new_validator_set = validators.clone();
-        new_validator_set.insert(new_validator.clone(), U512::from(9));
-
-        let era1_metadata = EraMetadata {
-            validators: &new_validator_set,
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
             faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
 
-        let expected_added_change = vec![(new_validator, ValidatorChange::Added)];
-        let actual_change = ValidatorChange::validator_changes(era0_metadata, era1_metadata);
+        let mut era1_metadata = era0_metadata.clone();
+        let added_validator = PublicKey::random(&mut rng);
+        era1_metadata.validators.insert(&added_validator);
 
-        assert_eq!(expected_added_change, actual_change);
+        let expected_change = vec![(added_validator.clone(), ValidatorChange::Added)];
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert_eq!(expected_change, actual_change);
     }
 
     #[test]
-    fn should_report_removed_status_change() {
+    fn should_report_removed() {
         let mut rng = crate::new_rng();
         let validators = preset_validators(&mut rng);
-        let removed_validator_key = PublicKey::random(&mut rng);
-        let era0_validator_set = {
-            let mut validators = validators.clone();
-            validators.insert(removed_validator_key.clone(), U512::from(9));
-            validators
-        };
-        let era0_metadata = EraMetadata {
-            validators: &era0_validator_set,
-            seen_as_faulty: vec![],
-            faulty: &Default::default(),
-            cannot_propose: &Default::default(),
-        };
+
         let era1_metadata = EraMetadata {
-            validators: &validators,
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
             faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
 
-        let expected_change = vec![(removed_validator_key, ValidatorChange::Removed)];
-        let actual_change = ValidatorChange::validator_changes(era0_metadata, era1_metadata);
+        let mut era0_metadata = era1_metadata.clone();
+        let removed_validator = PublicKey::random(&mut rng);
+        era0_metadata.validators.insert(&removed_validator);
+
+        let expected_change = vec![(removed_validator.clone(), ValidatorChange::Removed)];
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
         assert_eq!(expected_change, actual_change)
     }
 
     #[test]
-    fn should_report_seen_as_faulty_status_change() {
+    fn should_report_seen_as_faulty_in_new_era() {
+        let mut rng = crate::new_rng();
+
+        let seen_as_faulty_in_old_era = PublicKey::random(&mut rng);
+        let era0_metadata = EraMetadata {
+            validators: Default::default(),
+            seen_as_faulty: vec![&seen_as_faulty_in_old_era],
+            faulty: &Default::default(),
+            cannot_propose: &Default::default(),
+        };
+        let seen_as_faulty_in_new_era = PublicKey::random(&mut rng);
+        let era1_metadata = EraMetadata {
+            validators: Default::default(),
+            seen_as_faulty: vec![&seen_as_faulty_in_new_era],
+            faulty: &Default::default(),
+            cannot_propose: &Default::default(),
+        };
+
+        let expected_change = vec![(
+            seen_as_faulty_in_new_era.clone(),
+            ValidatorChange::SeenAsFaulty,
+        )];
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert_eq!(expected_change, actual_change)
+    }
+
+    #[test]
+    fn should_report_banned() {
         let mut rng = crate::new_rng();
         let validators = preset_validators(&mut rng);
-        let seen_as_faulty = PublicKey::random(&mut rng);
+
+        let faulty = validators.iter().next().unwrap();
+
         let era0_metadata = EraMetadata {
-            validators: &validators,
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
             faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
-        let era1_metadata = EraMetadata {
-            validators: &validators,
-            seen_as_faulty: vec![seen_as_faulty.clone()],
-            faulty: &Default::default(),
-            cannot_propose: &Default::default(),
-        };
 
-        let expected_change = vec![(seen_as_faulty, ValidatorChange::SeenAsFaulty)];
-        let actual_change = ValidatorChange::validator_changes(era0_metadata, era1_metadata);
+        let mut era1_metadata = era0_metadata.clone();
+        let faulty_set = iter::once(faulty.clone()).collect();
+        era1_metadata.faulty = &faulty_set;
+
+        let expected_change = vec![(faulty.clone(), ValidatorChange::Banned)];
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
         assert_eq!(expected_change, actual_change)
     }
 
     #[test]
-    fn should_report_banned_status_change() {
+    fn should_not_report_banned_if_in_both_eras() {
         let mut rng = crate::new_rng();
-        let mut validators = preset_validators(&mut rng);
+        let validators = preset_validators(&mut rng);
 
-        let faulty_key = PublicKey::random(&mut rng);
-        let mut faulty = HashSet::new();
-        faulty.insert(faulty_key.clone());
-
-        validators.insert(faulty_key.clone(), U512::from(9));
+        let faulty = validators.iter().next().unwrap();
 
         let era0_metadata = EraMetadata {
-            validators: &validators,
+            validators: validators.iter().collect(),
+            seen_as_faulty: vec![],
+            faulty: &iter::once(faulty.clone()).collect(),
+            cannot_propose: &Default::default(),
+        };
+        let era1_metadata = era0_metadata.clone();
+
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert!(actual_change.is_empty());
+    }
+
+    #[test]
+    fn should_not_report_banned_if_not_a_validator_in_new_era() {
+        let mut rng = crate::new_rng();
+        let validators = preset_validators(&mut rng);
+
+        let faulty = PublicKey::random(&mut rng);
+
+        let era0_metadata = EraMetadata {
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
             faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
-        let era1_metadata = EraMetadata {
-            validators: &validators,
+
+        let mut era1_metadata = era0_metadata.clone();
+        let faulty_set = iter::once(faulty).collect();
+        era1_metadata.faulty = &faulty_set;
+
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert!(actual_change.is_empty());
+    }
+
+    #[test]
+    fn should_report_cannot_propose() {
+        let mut rng = crate::new_rng();
+        let validators = preset_validators(&mut rng);
+
+        let cannot_propose = validators.iter().next().unwrap();
+
+        let era0_metadata = EraMetadata {
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
-            faulty: &faulty,
+            faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
 
-        let expected_change = vec![(faulty_key, ValidatorChange::Banned)];
-        let actual_change = ValidatorChange::validator_changes(era0_metadata, era1_metadata);
+        let mut era1_metadata = era0_metadata.clone();
+        let cannot_propose_set = iter::once(cannot_propose.clone()).collect();
+        era1_metadata.cannot_propose = &cannot_propose_set;
+
+        let expected_change = vec![(cannot_propose.clone(), ValidatorChange::CannotPropose)];
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
         assert_eq!(expected_change, actual_change)
     }
 
     #[test]
-    fn should_report_cannot_propose_status_change() {
+    fn should_not_report_cannot_propose_if_in_both_eras() {
         let mut rng = crate::new_rng();
-        let mut validators = preset_validators(&mut rng);
+        let validators = preset_validators(&mut rng);
 
-        let cannot_propose_key = PublicKey::random(&mut rng);
-        let mut cannot_propose = HashSet::new();
-        cannot_propose.insert(cannot_propose_key.clone());
-
-        validators.insert(cannot_propose_key.clone(), U512::from(9));
+        let cannot_propose = validators.iter().next().unwrap();
 
         let era0_metadata = EraMetadata {
-            validators: &validators,
+            validators: validators.iter().collect(),
+            seen_as_faulty: vec![],
+            faulty: &Default::default(),
+            cannot_propose: &iter::once(cannot_propose.clone()).collect(),
+        };
+        let era1_metadata = era0_metadata.clone();
+
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert!(actual_change.is_empty());
+    }
+
+    #[test]
+    fn should_not_report_cannot_propose_if_not_a_validator_in_new_era() {
+        let mut rng = crate::new_rng();
+        let validators = preset_validators(&mut rng);
+
+        let cannot_propose = PublicKey::random(&mut rng);
+
+        let era0_metadata = EraMetadata {
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
             faulty: &Default::default(),
             cannot_propose: &Default::default(),
         };
 
+        let mut era1_metadata = era0_metadata.clone();
+        let cannot_propose_set = iter::once(cannot_propose).collect();
+        era1_metadata.cannot_propose = &cannot_propose_set;
+
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert!(actual_change.is_empty());
+    }
+
+    #[test]
+    fn should_report_no_status_change() {
+        let mut rng = crate::new_rng();
+        let validators = preset_validators(&mut rng);
+
+        let era0_metadata = EraMetadata {
+            validators: validators.iter().collect(),
+            seen_as_faulty: validators.iter().collect(),
+            faulty: &validators,
+            cannot_propose: &validators,
+        };
         let era1_metadata = EraMetadata {
-            validators: &validators,
+            validators: validators.iter().collect(),
             seen_as_faulty: vec![],
-            faulty: &Default::default(),
-            cannot_propose: &cannot_propose,
+            faulty: &validators,
+            cannot_propose: &validators,
         };
 
-        let expected_change = vec![(cannot_propose_key, ValidatorChange::CannotPropose)];
-        let actual_change = ValidatorChange::validator_changes(era0_metadata, era1_metadata);
-        assert_eq!(expected_change, actual_change)
+        let actual_change = ValidatorChanges::new_from_metadata(era0_metadata, era1_metadata);
+        assert!(actual_change.is_empty());
     }
 }

--- a/node/src/components/rest_server/filters.rs
+++ b/node/src/components/rest_server/filters.rs
@@ -16,7 +16,7 @@ use super::ReactorEventT;
 use crate::{
     effect::{requests::RestRequest, EffectBuilder},
     reactor::QueueKind,
-    rpcs::info::{GetValidatorChangesResult, JsonEraChange, JsonValidatorInfo},
+    rpcs::info::GetValidatorChangesResult,
     types::GetStatusResult,
 };
 
@@ -107,23 +107,8 @@ pub(super) fn create_validator_changes_filter<REv: ReactorEventT>(
         .and_then(move || {
             effect_builder
                 .get_consensus_validator_changes()
-                .map(move |validator_info| {
-                    let json_validator_info = validator_info
-                        .into_iter()
-                        .map(|(public_key, era_changes)| {
-                            let era_changes = era_changes
-                                .into_iter()
-                                .map(|(era_id, validator_change)| {
-                                    JsonEraChange::new(era_id, validator_change)
-                                })
-                                .collect();
-                            JsonValidatorInfo::new(public_key, era_changes)
-                        })
-                        .collect();
-                    let result = GetValidatorChangesResult {
-                        api_version,
-                        changes_to_validators: json_validator_info,
-                    };
+                .map(move |changes| {
+                    let result = GetValidatorChangesResult::new(api_version, changes);
                     Ok::<_, Rejection>(reply::json(&result).into_response())
                 })
         })

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -337,14 +337,18 @@ mod tests {
 
     #[test]
     fn schema() {
-        // The expected schema depends on the hashing algorithm
-        // selected by the `casper-mainnet` feature.
-
-        // To generate a correct valid template, run the test with and without
-        // the feature enabled and output the 'actual_schema' to a terminal
-        // and save them to the valid template files.
-        // Note: Please review the diff of the template files to avoid any breaking
-        // changes.
+        // The expected schema depends on the hashing algorithm selected by the `casper-mainnet`
+        // feature.
+        //
+        // To generate the contents to replace the input JSON files, run the test with and without
+        // the feature enabled and print the `actual_schema_string` by uncommenting the `println!`
+        // towards the end of the test
+        // ```
+        // cargo t --features=casper-mainnet components::rpc_server::tests::schema -- --nocapture
+        // cargo t --no-default-features components::rpc_server::tests::schema -- --nocapture
+        // ```
+        //
+        // Note: Please review the diff of the input files to avoid any breaking changes.
 
         #[cfg(feature = "casper-mainnet")]
         let schema_path = format!(
@@ -362,8 +366,10 @@ mod tests {
         let expected_schema: Value = serde_json::from_str(expected_schema.trim()).unwrap();
 
         let actual_schema = schema_for_value!(OPEN_RPC_SCHEMA.clone());
-        let actual_schema = serde_json::to_string(&actual_schema).unwrap();
-        let actual_schema: Value = serde_json::from_str(&actual_schema).unwrap();
+        let actual_schema_string = serde_json::to_string_pretty(&actual_schema).unwrap();
+        let actual_schema: Value = serde_json::from_str(&actual_schema_string).unwrap();
+
+        // println!("{}", actual_schema_string);
 
         assert_json_eq!(actual_schema, expected_schema);
     }

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -83,9 +83,8 @@ pub(crate) static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
     );
     schema.push_without_params::<GetPeers>("returns a list of peers connected to the node");
     schema.push_without_params::<GetStatus>("returns the current status of the node");
-    schema.push_without_params::<GetValidatorChanges>(
-        "returns changes in validator status between any two eras",
-    );
+    schema
+        .push_without_params::<GetValidatorChanges>("returns status changes of active validators");
     schema.push_with_optional_params::<GetBlock>("returns a Block from the network");
     schema.push_with_optional_params::<GetBlockTransfers>(
         "returns all transfers for a Block from the network",

--- a/node/src/components/rpc_server/rpcs/info.rs
+++ b/node/src/components/rpc_server/rpcs/info.rs
@@ -3,7 +3,7 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-use std::str;
+use std::{collections::BTreeMap, str};
 
 use futures::{future::BoxFuture, FutureExt};
 use http::Response;
@@ -47,10 +47,10 @@ static GET_PEERS_RESULT: Lazy<GetPeersResult> = Lazy::new(|| GetPeersResult {
 static GET_VALIDATOR_CHANGES_RESULT: Lazy<GetValidatorChangesResult> = Lazy::new(|| {
     let era_changes = JsonEraChange::new(EraId::new(1), ValidatorChange::Added);
     let public_key = PublicKey::doc_example().clone();
-    let validator_info = vec![JsonValidatorInfo::new(public_key, vec![era_changes])];
+    let validator_info = vec![JsonValidatorChanges::new(public_key, vec![era_changes])];
     GetValidatorChangesResult {
         api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
-        changes_to_validators: validator_info,
+        changes: validator_info,
     }
 });
 
@@ -237,7 +237,7 @@ impl RpcWithoutParamsExt for GetStatus {
     }
 }
 
-/// A single change to a validator's status between two eras.
+/// A single change to a validator's status in the given era.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JsonEraChange {
@@ -256,19 +256,19 @@ impl JsonEraChange {
     }
 }
 
-/// The changes in a validator's status between any two eras.
+/// The changes in a validator's status.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct JsonValidatorInfo {
-    /// The public key of a given validator.
+pub struct JsonValidatorChanges {
+    /// The public key of the validator.
     public_key: PublicKey,
     /// The set of changes to the validator's status.
     status_changes: Vec<JsonEraChange>,
 }
 
-impl JsonValidatorInfo {
+impl JsonValidatorChanges {
     pub(crate) fn new(public_key: PublicKey, status_changes: Vec<JsonEraChange>) -> Self {
-        JsonValidatorInfo {
+        JsonValidatorChanges {
             public_key,
             status_changes,
         }
@@ -282,8 +282,31 @@ pub struct GetValidatorChangesResult {
     /// The RPC API version.
     #[schemars(with = "String")]
     pub api_version: ProtocolVersion,
-    /// The validator information.
-    pub changes_to_validators: Vec<JsonValidatorInfo>,
+    /// The validators' status changes.
+    pub changes: Vec<JsonValidatorChanges>,
+}
+
+impl GetValidatorChangesResult {
+    pub(crate) fn new(
+        api_version: ProtocolVersion,
+        changes: BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>,
+    ) -> Self {
+        let changes = changes
+            .into_iter()
+            .map(|(public_key, mut validator_changes)| {
+                validator_changes.sort();
+                let status_changes = validator_changes
+                    .into_iter()
+                    .map(|(era_id, validator_change)| JsonEraChange::new(era_id, validator_change))
+                    .collect();
+                JsonValidatorChanges::new(public_key, status_changes)
+            })
+            .collect();
+        GetValidatorChangesResult {
+            api_version,
+            changes,
+        }
+    }
 }
 
 impl DocExample for GetValidatorChangesResult {
@@ -307,25 +330,8 @@ impl RpcWithoutParamsExt for GetValidatorChanges {
         api_version: ProtocolVersion,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
-            // Get the validator info.
-            let validator_info = effect_builder
-                .get_consensus_validator_changes()
-                .await
-                .into_iter()
-                .map(|(public_key, era_changes)| {
-                    let era_changes = era_changes
-                        .into_iter()
-                        .map(|(era_id, validator_change)| {
-                            JsonEraChange::new(era_id, validator_change)
-                        })
-                        .collect();
-                    JsonValidatorInfo::new(public_key, era_changes)
-                })
-                .collect();
-            let result = Self::ResponseResult {
-                api_version,
-                changes_to_validators: validator_info,
-            };
+            let changes = effect_builder.get_consensus_validator_changes().await;
+            let result = Self::ResponseResult::new(api_version, changes);
             Ok(response_builder.success(result)?)
         }
         .boxed()

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -1,215 +1,215 @@
 {
-  "$schema":"http://json-schema.org/draft-07/schema#",
-  "title":"OpenRpcSchema",
-  "examples":[
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenRpcSchema",
+  "examples": [
     {
-      "components":{
-        "schemas":{
-          "Account":{
-            "additionalProperties":false,
-            "description":"Structure representing a user's account, stored in global state.",
-            "properties":{
-              "account_hash":{
-                "$ref":"#/components/schemas/AccountHash"
+      "components": {
+        "schemas": {
+          "Account": {
+            "additionalProperties": false,
+            "description": "Structure representing a user's account, stored in global state.",
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
               },
-              "action_thresholds":{
-                "$ref":"#/components/schemas/ActionThresholds"
+              "action_thresholds": {
+                "$ref": "#/components/schemas/ActionThresholds"
               },
-              "associated_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/AssociatedKey"
+              "associated_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/AssociatedKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "main_purse":{
-                "$ref":"#/components/schemas/URef"
+              "main_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "named_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/NamedKey"
+              "named_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "account_hash",
               "action_thresholds",
               "associated_keys",
               "main_purse",
               "named_keys"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AccountHash":{
-            "description":"Hex-encoded account hash.",
-            "type":"string"
+          "AccountHash": {
+            "description": "Hex-encoded account hash.",
+            "type": "string"
           },
-          "ActionThresholds":{
-            "additionalProperties":false,
-            "description":"Thresholds that have to be met when executing an action of a certain type.",
-            "properties":{
-              "deployment":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+          "ActionThresholds": {
+            "additionalProperties": false,
+            "description": "Thresholds that have to be met when executing an action of a certain type.",
+            "properties": {
+              "deployment": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "key_management":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "key_management": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "deployment",
               "key_management"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ActivationPoint":{
-            "anyOf":[
+          "ActivationPoint": {
+            "anyOf": [
               {
-                "$ref":"#/components/schemas/EraId"
+                "$ref": "#/components/schemas/EraId"
               },
               {
-                "$ref":"#/components/schemas/Timestamp"
+                "$ref": "#/components/schemas/Timestamp"
               }
             ],
-            "description":"The first era to which the associated protocol version applies."
+            "description": "The first era to which the associated protocol version applies."
           },
-          "Approval":{
-            "additionalProperties":false,
-            "description":"A struct containing a signature and the public key of the signer.",
-            "properties":{
-              "signature":{
-                "$ref":"#/components/schemas/Signature"
+          "Approval": {
+            "additionalProperties": false,
+            "description": "A struct containing a signature and the public key of the signer.",
+            "properties": {
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
               },
-              "signer":{
-                "$ref":"#/components/schemas/PublicKey"
+              "signer": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "signature",
               "signer"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AssociatedKey":{
-            "additionalProperties":false,
-            "properties":{
-              "account_hash":{
-                "$ref":"#/components/schemas/AccountHash"
+          "AssociatedKey": {
+            "additionalProperties": false,
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
               },
-              "weight":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "weight": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "account_hash",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AuctionState":{
-            "additionalProperties":false,
-            "description":"Data structure summarizing auction contract data.",
-            "properties":{
-              "bids":{
-                "description":"All bids contained within a vector.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonBids"
+          "AuctionState": {
+            "additionalProperties": false,
+            "description": "Data structure summarizing auction contract data.",
+            "properties": {
+              "bids": {
+                "description": "All bids contained within a vector.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonBids"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "block_height":{
-                "description":"Block height.",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "block_height": {
+                "description": "Block height.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "era_validators":{
-                "description":"Era validators.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonEraValidators"
+              "era_validators": {
+                "description": "Era validators.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonEraValidators"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Global state hash."
+                "description": "Global state hash."
               }
             },
-            "required":[
+            "required": [
               "bids",
               "block_height",
               "era_validators",
               "state_root_hash"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Bid":{
-            "additionalProperties":false,
-            "description":"An entry in the validator map.",
-            "properties":{
-              "bonding_purse":{
-                "allOf":[
+          "Bid": {
+            "additionalProperties": false,
+            "description": "An entry in the validator map.",
+            "properties": {
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"The purse that was used for bonding."
+                "description": "The purse that was used for bonding."
               },
-              "delegation_rate":{
-                "description":"Delegation rate",
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "delegation_rate": {
+                "description": "Delegation rate",
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "delegators":{
-                "additionalProperties":{
-                  "$ref":"#/components/schemas/Delegator"
+              "delegators": {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Delegator"
                 },
-                "description":"This validator's delegators, indexed by their public keys",
-                "type":"object"
+                "description": "This validator's delegators, indexed by their public keys",
+                "type": "object"
               },
-              "inactive":{
-                "description":"`true` if validator has been \"evicted\"",
-                "type":"boolean"
+              "inactive": {
+                "description": "`true` if validator has been \"evicted\"",
+                "type": "boolean"
               },
-              "staked_amount":{
-                "allOf":[
+              "staked_amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"The amount of tokens staked by a validator (not including delegators)."
+                "description": "The amount of tokens staked by a validator (not including delegators)."
               },
-              "validator_public_key":{
-                "allOf":[
+              "validator_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Validator public key"
+                "description": "Validator public key"
               },
-              "vesting_schedule":{
-                "anyOf":[
+              "vesting_schedule": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/VestingSchedule"
+                    "$ref": "#/components/schemas/VestingSchedule"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"Vesting schedule for a genesis validator. `None` if non-genesis validator."
+                "description": "Vesting schedule for a genesis validator. `None` if non-genesis validator."
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegation_rate",
               "delegators",
@@ -217,53 +217,53 @@
               "staked_amount",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "BlockHash":{
-            "allOf":[
+          "BlockHash": {
+            "allOf": [
               {
-                "$ref":"#/components/schemas/Digest"
+                "$ref": "#/components/schemas/Digest"
               }
             ],
-            "description":"A cryptographic hash identifying a [`Block`](struct.Block.html)."
+            "description": "A cryptographic hash identifying a [`Block`](struct.Block.html)."
           },
-          "BlockIdentifier":{
-            "anyOf":[
+          "BlockIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Identify and retrieve the block with its hash.",
-                "properties":{
-                  "Hash":{
-                    "$ref":"#/components/schemas/BlockHash"
+                "additionalProperties": false,
+                "description": "Identify and retrieve the block with its hash.",
+                "properties": {
+                  "Hash": {
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 },
-                "required":[
+                "required": [
                   "Hash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Identify and retrieve the block with its height.",
-                "properties":{
-                  "Height":{
-                    "format":"uint64",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Identify and retrieve the block with its height.",
+                "properties": {
+                  "Height": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "Height"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Identifier for possible ways to retrieve a block."
+            "description": "Identifier for possible ways to retrieve a block."
           },
-          "CLType":{
-            "anyOf":[
+          "CLType": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Bool",
                   "I32",
                   "I64",
@@ -280,387 +280,387 @@
                   "PublicKey",
                   "Any"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"`Option` of a `CLType`.",
-                "properties":{
-                  "Option":{
-                    "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "`Option` of a `CLType`.",
+                "properties": {
+                  "Option": {
+                    "$ref": "#/components/schemas/CLType"
                   }
                 },
-                "required":[
+                "required": [
                   "Option"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Variable-length list of a single `CLType` (comparable to a `Vec`).",
-                "properties":{
-                  "List":{
-                    "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "Variable-length list of a single `CLType` (comparable to a `Vec`).",
+                "properties": {
+                  "List": {
+                    "$ref": "#/components/schemas/CLType"
                   }
                 },
-                "required":[
+                "required": [
                   "List"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Fixed-length list of a single `CLType` (comparable to a Rust array).",
-                "properties":{
-                  "ByteArray":{
-                    "format":"uint32",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Fixed-length list of a single `CLType` (comparable to a Rust array).",
+                "properties": {
+                  "ByteArray": {
+                    "format": "uint32",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "ByteArray"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"`Result` with `Ok` and `Err` variants of `CLType`s.",
-                "properties":{
-                  "Result":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "err":{
-                        "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "`Result` with `Ok` and `Err` variants of `CLType`s.",
+                "properties": {
+                  "Result": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "err": {
+                        "$ref": "#/components/schemas/CLType"
                       },
-                      "ok":{
-                        "$ref":"#/components/schemas/CLType"
+                      "ok": {
+                        "$ref": "#/components/schemas/CLType"
                       }
                     },
-                    "required":[
+                    "required": [
                       "err",
                       "ok"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Result"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Map with keys of a single `CLType` and values of a single `CLType`.",
-                "properties":{
-                  "Map":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "key":{
-                        "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "Map with keys of a single `CLType` and values of a single `CLType`.",
+                "properties": {
+                  "Map": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "$ref": "#/components/schemas/CLType"
                       },
-                      "value":{
-                        "$ref":"#/components/schemas/CLType"
+                      "value": {
+                        "$ref": "#/components/schemas/CLType"
                       }
                     },
-                    "required":[
+                    "required": [
                       "key",
                       "value"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Map"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"1-ary tuple of a `CLType`.",
-                "properties":{
-                  "Tuple1":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "1-ary tuple of a `CLType`.",
+                "properties": {
+                  "Tuple1": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":1,
-                    "minItems":1,
-                    "type":"array"
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple1"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"2-ary tuple of `CLType`s.",
-                "properties":{
-                  "Tuple2":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "2-ary tuple of `CLType`s.",
+                "properties": {
+                  "Tuple2": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":2,
-                    "minItems":2,
-                    "type":"array"
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple2"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"3-ary tuple of `CLType`s.",
-                "properties":{
-                  "Tuple3":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "3-ary tuple of `CLType`s.",
+                "properties": {
+                  "Tuple3": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":3,
-                    "minItems":3,
-                    "type":"array"
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple3"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue)."
+            "description": "Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue)."
           },
-          "CLValue":{
-            "additionalProperties":false,
-            "description":"A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
-            "properties":{
-              "bytes":{
-                "type":"string"
+          "CLValue": {
+            "additionalProperties": false,
+            "description": "A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
+            "properties": {
+              "bytes": {
+                "type": "string"
               },
-              "cl_type":{
-                "$ref":"#/components/schemas/CLType"
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
               },
-              "parsed":true
+              "parsed": true
             },
-            "required":[
+            "required": [
               "bytes",
               "cl_type"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Contract":{
-            "additionalProperties":false,
-            "description":"A contract struct that can be serialized as  JSON object.",
-            "properties":{
-              "contract_package_hash":{
-                "$ref":"#/components/schemas/ContractPackageHash"
+          "Contract": {
+            "additionalProperties": false,
+            "description": "A contract struct that can be serialized as  JSON object.",
+            "properties": {
+              "contract_package_hash": {
+                "$ref": "#/components/schemas/ContractPackageHash"
               },
-              "contract_wasm_hash":{
-                "$ref":"#/components/schemas/ContractWasmHash"
+              "contract_wasm_hash": {
+                "$ref": "#/components/schemas/ContractWasmHash"
               },
-              "entry_points":{
-                "items":{
-                  "$ref":"#/components/schemas/EntryPoint"
+              "entry_points": {
+                "items": {
+                  "$ref": "#/components/schemas/EntryPoint"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "named_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/NamedKey"
+              "named_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "protocol_version":{
-                "type":"string"
+              "protocol_version": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "contract_package_hash",
               "contract_wasm_hash",
               "entry_points",
               "named_keys",
               "protocol_version"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractHash":{
-            "description":"The hash address of the contract",
-            "type":"string"
+          "ContractHash": {
+            "description": "The hash address of the contract",
+            "type": "string"
           },
-          "ContractPackage":{
-            "additionalProperties":false,
-            "description":"Contract definition, metadata, and security container.",
-            "properties":{
-              "access_key":{
-                "$ref":"#/components/schemas/URef"
+          "ContractPackage": {
+            "additionalProperties": false,
+            "description": "Contract definition, metadata, and security container.",
+            "properties": {
+              "access_key": {
+                "$ref": "#/components/schemas/URef"
               },
-              "disabled_versions":{
-                "items":{
-                  "$ref":"#/components/schemas/DisabledVersion"
+              "disabled_versions": {
+                "items": {
+                  "$ref": "#/components/schemas/DisabledVersion"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "groups":{
-                "items":{
-                  "$ref":"#/components/schemas/Groups"
+              "groups": {
+                "items": {
+                  "$ref": "#/components/schemas/Groups"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "versions":{
-                "items":{
-                  "$ref":"#/components/schemas/ContractVersion"
+              "versions": {
+                "items": {
+                  "$ref": "#/components/schemas/ContractVersion"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "access_key",
               "disabled_versions",
               "groups",
               "versions"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractPackageHash":{
-            "description":"The hash address of the contract package",
-            "type":"string"
+          "ContractPackageHash": {
+            "description": "The hash address of the contract package",
+            "type": "string"
           },
-          "ContractVersion":{
-            "properties":{
-              "contract_hash":{
-                "$ref":"#/components/schemas/ContractHash"
+          "ContractVersion": {
+            "properties": {
+              "contract_hash": {
+                "$ref": "#/components/schemas/ContractHash"
               },
-              "contract_version":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "contract_version": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "protocol_version_major":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "protocol_version_major": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "contract_hash",
               "contract_version",
               "protocol_version_major"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractWasmHash":{
-            "description":"The hash address of the contract wasm",
-            "type":"string"
+          "ContractWasmHash": {
+            "description": "The hash address of the contract wasm",
+            "type": "string"
           },
-          "Delegator":{
-            "additionalProperties":false,
-            "description":"Represents a party delegating their stake to a validator (or \"delegatee\")",
-            "properties":{
-              "bonding_purse":{
-                "$ref":"#/components/schemas/URef"
+          "Delegator": {
+            "additionalProperties": false,
+            "description": "Represents a party delegating their stake to a validator (or \"delegatee\")",
+            "properties": {
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "delegator_public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "delegator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "staked_amount":{
-                "$ref":"#/components/schemas/U512"
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
               },
-              "validator_public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "validator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "vesting_schedule":{
-                "anyOf":[
+              "vesting_schedule": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/VestingSchedule"
+                    "$ref": "#/components/schemas/VestingSchedule"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ]
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegator_public_key",
               "staked_amount",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Deploy":{
-            "additionalProperties":false,
-            "description":"A deploy; an item containing a smart contract along with the requester's signature(s).",
-            "properties":{
-              "approvals":{
-                "items":{
-                  "$ref":"#/components/schemas/Approval"
+          "Deploy": {
+            "additionalProperties": false,
+            "description": "A deploy; an item containing a smart contract along with the requester's signature(s).",
+            "properties": {
+              "approvals": {
+                "items": {
+                  "$ref": "#/components/schemas/Approval"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "hash":{
-                "$ref":"#/components/schemas/DeployHash"
+              "hash": {
+                "$ref": "#/components/schemas/DeployHash"
               },
-              "header":{
-                "$ref":"#/components/schemas/DeployHeader"
+              "header": {
+                "$ref": "#/components/schemas/DeployHeader"
               },
-              "payment":{
-                "$ref":"#/components/schemas/ExecutableDeployItem"
+              "payment": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
               },
-              "session":{
-                "$ref":"#/components/schemas/ExecutableDeployItem"
+              "session": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
               }
             },
-            "required":[
+            "required": [
               "approvals",
               "hash",
               "header",
               "payment",
               "session"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DeployHash":{
-            "allOf":[
+          "DeployHash": {
+            "allOf": [
               {
-                "$ref":"#/components/schemas/Digest"
+                "$ref": "#/components/schemas/Digest"
               }
             ],
-            "description":"Hex-encoded deploy hash."
+            "description": "Hex-encoded deploy hash."
           },
-          "DeployHeader":{
-            "additionalProperties":false,
-            "description":"The header portion of a [`Deploy`](struct.Deploy.html).",
-            "properties":{
-              "account":{
-                "$ref":"#/components/schemas/PublicKey"
+          "DeployHeader": {
+            "additionalProperties": false,
+            "description": "The header portion of a [`Deploy`](struct.Deploy.html).",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "body_hash":{
-                "$ref":"#/components/schemas/Digest"
+              "body_hash": {
+                "$ref": "#/components/schemas/Digest"
               },
-              "chain_name":{
-                "type":"string"
+              "chain_name": {
+                "type": "string"
               },
-              "dependencies":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+              "dependencies": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "gas_price":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "gas_price": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "timestamp":{
-                "$ref":"#/components/schemas/Timestamp"
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
               },
-              "ttl":{
-                "$ref":"#/components/schemas/TimeDiff"
+              "ttl": {
+                "$ref": "#/components/schemas/TimeDiff"
               }
             },
-            "required":[
+            "required": [
               "account",
               "body_hash",
               "chain_name",
@@ -669,910 +669,910 @@
               "timestamp",
               "ttl"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DeployInfo":{
-            "additionalProperties":false,
-            "description":"Information relating to the given Deploy.",
-            "properties":{
-              "deploy_hash":{
-                "allOf":[
+          "DeployInfo": {
+            "additionalProperties": false,
+            "description": "Information relating to the given Deploy.",
+            "properties": {
+              "deploy_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/DeployHash"
+                    "$ref": "#/components/schemas/DeployHash"
                   }
                 ],
-                "description":"The relevant Deploy."
+                "description": "The relevant Deploy."
               },
-              "from":{
-                "allOf":[
+              "from": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 ],
-                "description":"Account identifier of the creator of the Deploy."
+                "description": "Account identifier of the creator of the Deploy."
               },
-              "gas":{
-                "allOf":[
+              "gas": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Gas cost of executing the Deploy."
+                "description": "Gas cost of executing the Deploy."
               },
-              "source":{
-                "allOf":[
+              "source": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Source purse used for payment of the Deploy."
+                "description": "Source purse used for payment of the Deploy."
               },
-              "transfers":{
-                "description":"Transfers performed by the Deploy.",
-                "items":{
-                  "$ref":"#/components/schemas/TransferAddr"
+              "transfers": {
+                "description": "Transfers performed by the Deploy.",
+                "items": {
+                  "$ref": "#/components/schemas/TransferAddr"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "deploy_hash",
               "from",
               "gas",
               "source",
               "transfers"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DictionaryIdentifier":{
-            "anyOf":[
+          "DictionaryIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via an Account's named keys.",
-                "properties":{
-                  "AccountNamedKey":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via an Account's named keys.",
+                "properties": {
+                  "AccountNamedKey": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "dictionary_name":{
-                        "description":"The named key under which the dictionary seed URef is stored.",
-                        "type":"string"
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
                       },
-                      "key":{
-                        "description":"The account key as a formatted string whose named keys contains dictionary_name.",
-                        "type":"string"
+                      "key": {
+                        "description": "The account key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "dictionary_name",
                       "key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "AccountNamedKey"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via a Contract's named keys.",
-                "properties":{
-                  "ContractNamedKey":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via a Contract's named keys.",
+                "properties": {
+                  "ContractNamedKey": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "dictionary_name":{
-                        "description":"The named key under which the dictionary seed URef is stored.",
-                        "type":"string"
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
                       },
-                      "key":{
-                        "description":"The contract key as a formatted string whose named keys contains dictionary_name.",
-                        "type":"string"
+                      "key": {
+                        "description": "The contract key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "dictionary_name",
                       "key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractNamedKey"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via its seed URef.",
-                "properties":{
-                  "URef":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via its seed URef.",
+                "properties": {
+                  "URef": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "seed_uref":{
-                        "description":"The dictionary's seed URef.",
-                        "type":"string"
+                      "seed_uref": {
+                        "description": "The dictionary's seed URef.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "seed_uref"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "URef"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via its unique key.",
-                "properties":{
-                  "Dictionary":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via its unique key.",
+                "properties": {
+                  "Dictionary": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "Dictionary"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Options for dictionary item lookups."
+            "description": "Options for dictionary item lookups."
           },
-          "Digest":{
-            "description":"Hex-encoded hash digest.",
-            "type":"string"
+          "Digest": {
+            "description": "Hex-encoded hash digest.",
+            "type": "string"
           },
-          "DisabledVersion":{
-            "properties":{
-              "contract_version":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+          "DisabledVersion": {
+            "properties": {
+              "contract_version": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "protocol_version_major":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "protocol_version_major": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "contract_version",
               "protocol_version_major"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EntryPoint":{
-            "description":"Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
-            "properties":{
-              "access":{
-                "$ref":"#/components/schemas/EntryPointAccess"
+          "EntryPoint": {
+            "description": "Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
+            "properties": {
+              "access": {
+                "$ref": "#/components/schemas/EntryPointAccess"
               },
-              "args":{
-                "items":{
-                  "$ref":"#/components/schemas/Parameter"
+              "args": {
+                "items": {
+                  "$ref": "#/components/schemas/Parameter"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "entry_point_type":{
-                "$ref":"#/components/schemas/EntryPointType"
+              "entry_point_type": {
+                "$ref": "#/components/schemas/EntryPointType"
               },
-              "name":{
-                "type":"string"
+              "name": {
+                "type": "string"
               },
-              "ret":{
-                "$ref":"#/components/schemas/CLType"
+              "ret": {
+                "$ref": "#/components/schemas/CLType"
               }
             },
-            "required":[
+            "required": [
               "access",
               "args",
               "entry_point_type",
               "name",
               "ret"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EntryPointAccess":{
-            "anyOf":[
+          "EntryPointAccess": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Public"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
-                "properties":{
-                  "Groups":{
-                    "items":{
-                      "$ref":"#/components/schemas/Group"
+                "additionalProperties": false,
+                "description": "Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
+                "properties": {
+                  "Groups": {
+                    "items": {
+                      "$ref": "#/components/schemas/Group"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Groups"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Enum describing the possible access control options for a contract entry point (method)."
+            "description": "Enum describing the possible access control options for a contract entry point (method)."
           },
-          "EntryPointType":{
-            "description":"Context of method execution",
-            "enum":[
+          "EntryPointType": {
+            "description": "Context of method execution",
+            "enum": [
               "Session",
               "Contract"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "EraId":{
-            "description":"Era ID newtype.",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "EraId": {
+            "description": "Era ID newtype.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "EraInfo":{
-            "additionalProperties":false,
-            "description":"Auction metadata.  Intended to be recorded at each era.",
-            "properties":{
-              "seigniorage_allocations":{
-                "items":{
-                  "$ref":"#/components/schemas/SeigniorageAllocation"
+          "EraInfo": {
+            "additionalProperties": false,
+            "description": "Auction metadata.  Intended to be recorded at each era.",
+            "properties": {
+              "seigniorage_allocations": {
+                "items": {
+                  "$ref": "#/components/schemas/SeigniorageAllocation"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "seigniorage_allocations"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EraSummary":{
-            "additionalProperties":false,
-            "description":"The summary of an era",
-            "properties":{
-              "block_hash":{
-                "allOf":[
+          "EraSummary": {
+            "additionalProperties": false,
+            "description": "The summary of an era",
+            "properties": {
+              "block_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The block hash"
+                "description": "The block hash"
               },
-              "era_id":{
-                "allOf":[
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The era id"
+                "description": "The era id"
               },
-              "merkle_proof":{
-                "description":"The merkle proof",
-                "type":"string"
+              "merkle_proof": {
+                "description": "The merkle proof",
+                "type": "string"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Hex-encoded hash of the state root"
+                "description": "Hex-encoded hash of the state root"
               },
-              "stored_value":{
-                "allOf":[
+              "stored_value": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/StoredValue"
+                    "$ref": "#/components/schemas/StoredValue"
                   }
                 ],
-                "description":"The StoredValue containing era information"
+                "description": "The StoredValue containing era information"
               }
             },
-            "required":[
+            "required": [
               "block_hash",
               "era_id",
               "merkle_proof",
               "state_root_hash",
               "stored_value"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ExecutableDeployItem":{
-            "anyOf":[
+          "ExecutableDeployItem": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "properties":{
-                  "ModuleBytes":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "ModuleBytes": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "module_bytes":{
-                        "description":"Hex-encoded raw Wasm bytes.",
-                        "type":"string"
+                      "module_bytes": {
+                        "description": "Hex-encoded raw Wasm bytes.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "module_bytes"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "ModuleBytes"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredContractByHash":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredContractByHash": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "hash":{
-                        "description":"Hex-encoded hash.",
-                        "type":"string"
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "hash"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredContractByHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredContractByName":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredContractByName": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "name":{
-                        "type":"string"
+                      "name": {
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "name"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredContractByName"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredVersionedContractByHash":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredVersionedContractByHash": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "hash":{
-                        "description":"Hex-encoded hash.",
-                        "type":"string"
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
                       },
-                      "version":{
-                        "format":"uint32",
-                        "minimum":0.0,
-                        "type":[
+                      "version": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
                           "integer",
                           "null"
                         ]
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "hash"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredVersionedContractByHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredVersionedContractByName":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredVersionedContractByName": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "name":{
-                        "type":"string"
+                      "name": {
+                        "type": "string"
                       },
-                      "version":{
-                        "format":"uint32",
-                        "minimum":0.0,
-                        "type":[
+                      "version": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
                           "integer",
                           "null"
                         ]
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "name"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredVersionedContractByName"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "Transfer":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "Transfer": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Transfer"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ]
           },
-          "ExecutionEffect":{
-            "additionalProperties":false,
-            "description":"The effect of executing a single deploy.",
-            "properties":{
-              "operations":{
-                "description":"The resulting operations.",
-                "items":{
-                  "$ref":"#/components/schemas/Operation"
+          "ExecutionEffect": {
+            "additionalProperties": false,
+            "description": "The effect of executing a single deploy.",
+            "properties": {
+              "operations": {
+                "description": "The resulting operations.",
+                "items": {
+                  "$ref": "#/components/schemas/Operation"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "transforms":{
-                "description":"The resulting transformations.",
-                "items":{
-                  "$ref":"#/components/schemas/TransformEntry"
+              "transforms": {
+                "description": "The resulting transformations.",
+                "items": {
+                  "$ref": "#/components/schemas/TransformEntry"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "operations",
               "transforms"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ExecutionResult":{
-            "anyOf":[
+          "ExecutionResult": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"The result of a failed execution.",
-                "properties":{
-                  "Failure":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "cost":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "The result of a failed execution.",
+                "properties": {
+                  "Failure": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "cost": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"The cost of executing the deploy."
+                        "description": "The cost of executing the deploy."
                       },
-                      "effect":{
-                        "allOf":[
+                      "effect": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/ExecutionEffect"
+                            "$ref": "#/components/schemas/ExecutionEffect"
                           }
                         ],
-                        "description":"The effect of executing the deploy."
+                        "description": "The effect of executing the deploy."
                       },
-                      "error_message":{
-                        "description":"The error message associated with executing the deploy.",
-                        "type":"string"
+                      "error_message": {
+                        "description": "The error message associated with executing the deploy.",
+                        "type": "string"
                       },
-                      "transfers":{
-                        "description":"A record of Transfers performed while executing the deploy.",
-                        "items":{
-                          "$ref":"#/components/schemas/TransferAddr"
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
                         },
-                        "type":"array"
+                        "type": "array"
                       }
                     },
-                    "required":[
+                    "required": [
                       "cost",
                       "effect",
                       "error_message",
                       "transfers"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Failure"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"The result of a successful execution.",
-                "properties":{
-                  "Success":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "cost":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "The result of a successful execution.",
+                "properties": {
+                  "Success": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "cost": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"The cost of executing the deploy."
+                        "description": "The cost of executing the deploy."
                       },
-                      "effect":{
-                        "allOf":[
+                      "effect": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/ExecutionEffect"
+                            "$ref": "#/components/schemas/ExecutionEffect"
                           }
                         ],
-                        "description":"The effect of executing the deploy."
+                        "description": "The effect of executing the deploy."
                       },
-                      "transfers":{
-                        "description":"A record of Transfers performed while executing the deploy.",
-                        "items":{
-                          "$ref":"#/components/schemas/TransferAddr"
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
                         },
-                        "type":"array"
+                        "type": "array"
                       }
                     },
-                    "required":[
+                    "required": [
                       "cost",
                       "effect",
                       "transfers"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Success"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"The result of executing a single deploy."
+            "description": "The result of executing a single deploy."
           },
-          "GlobalStateIdentifier":{
-            "anyOf":[
+          "GlobalStateIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Query using a block hash.",
-                "properties":{
-                  "BlockHash":{
-                    "$ref":"#/components/schemas/BlockHash"
+                "additionalProperties": false,
+                "description": "Query using a block hash.",
+                "properties": {
+                  "BlockHash": {
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 },
-                "required":[
+                "required": [
                   "BlockHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Query using the state root hash.",
-                "properties":{
-                  "StateRootHash":{
-                    "$ref":"#/components/schemas/Digest"
+                "additionalProperties": false,
+                "description": "Query using the state root hash.",
+                "properties": {
+                  "StateRootHash": {
+                    "$ref": "#/components/schemas/Digest"
                   }
                 },
-                "required":[
+                "required": [
                   "StateRootHash"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Identifier for possible ways to query Global State"
+            "description": "Identifier for possible ways to query Global State"
           },
-          "Group":{
-            "description":"A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
-            "type":"string"
+          "Group": {
+            "description": "A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
+            "type": "string"
           },
-          "Groups":{
-            "properties":{
-              "group":{
-                "type":"string"
+          "Groups": {
+            "properties": {
+              "group": {
+                "type": "string"
               },
-              "keys":{
-                "items":{
-                  "$ref":"#/components/schemas/URef"
+              "keys": {
+                "items": {
+                  "$ref": "#/components/schemas/URef"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "group",
               "keys"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBid":{
-            "additionalProperties":false,
-            "description":"An entry in a founding validator map representing a bid.",
-            "properties":{
-              "bonding_purse":{
-                "allOf":[
+          "JsonBid": {
+            "additionalProperties": false,
+            "description": "An entry in a founding validator map representing a bid.",
+            "properties": {
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"The purse that was used for bonding."
+                "description": "The purse that was used for bonding."
               },
-              "delegation_rate":{
-                "description":"The delegation rate.",
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "delegation_rate": {
+                "description": "The delegation rate.",
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "delegators":{
-                "description":"The delegators.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonDelegator"
+              "delegators": {
+                "description": "The delegators.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonDelegator"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "inactive":{
-                "description":"Is this an inactive validator.",
-                "type":"boolean"
+              "inactive": {
+                "description": "Is this an inactive validator.",
+                "type": "boolean"
               },
-              "staked_amount":{
-                "allOf":[
+              "staked_amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"The amount of tokens staked by a validator (not including delegators)."
+                "description": "The amount of tokens staked by a validator (not including delegators)."
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegation_rate",
               "delegators",
               "inactive",
               "staked_amount"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBids":{
-            "additionalProperties":false,
-            "description":"A Json representation of a single bid.",
-            "properties":{
-              "bid":{
-                "$ref":"#/components/schemas/JsonBid"
+          "JsonBids": {
+            "additionalProperties": false,
+            "description": "A Json representation of a single bid.",
+            "properties": {
+              "bid": {
+                "$ref": "#/components/schemas/JsonBid"
               },
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "bid",
               "public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlock":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of `Block`.",
-            "properties":{
-              "body":{
-                "allOf":[
+          "JsonBlock": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of `Block`.",
+            "properties": {
+              "body": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/JsonBlockBody"
+                    "$ref": "#/components/schemas/JsonBlockBody"
                   }
                 ],
-                "description":"JSON-friendly block body."
+                "description": "JSON-friendly block body."
               },
-              "hash":{
-                "allOf":[
+              "hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"`BlockHash`"
+                "description": "`BlockHash`"
               },
-              "header":{
-                "allOf":[
+              "header": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/JsonBlockHeader"
+                    "$ref": "#/components/schemas/JsonBlockHeader"
                   }
                 ],
-                "description":"JSON-friendly block header."
+                "description": "JSON-friendly block header."
               },
-              "proofs":{
-                "description":"JSON-friendly list of proofs for this block.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonProof"
+              "proofs": {
+                "description": "JSON-friendly list of proofs for this block.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonProof"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "body",
               "hash",
               "header",
               "proofs"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlockBody":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of `Body`",
-            "properties":{
-              "deploy_hashes":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+          "JsonBlockBody": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of `Body`",
+            "properties": {
+              "deploy_hashes": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "proposer":{
-                "$ref":"#/components/schemas/PublicKey"
+              "proposer": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "transfer_hashes":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+              "transfer_hashes": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "deploy_hashes",
               "proposer",
               "transfer_hashes"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlockHeader":{
-            "additionalProperties":false,
-            "description":"JSON representation of a block header.",
-            "properties":{
-              "accumulated_seed":{
-                "allOf":[
+          "JsonBlockHeader": {
+            "additionalProperties": false,
+            "description": "JSON representation of a block header.",
+            "properties": {
+              "accumulated_seed": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Accumulated seed."
+                "description": "Accumulated seed."
               },
-              "body_hash":{
-                "allOf":[
+              "body_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"The body hash."
+                "description": "The body hash."
               },
-              "era_end":{
-                "anyOf":[
+              "era_end": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/JsonEraEnd"
+                    "$ref": "#/components/schemas/JsonEraEnd"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"The era end."
+                "description": "The era end."
               },
-              "era_id":{
-                "allOf":[
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The block era id."
+                "description": "The block era id."
               },
-              "height":{
-                "description":"The block height.",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "height": {
+                "description": "The block height.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "parent_hash":{
-                "allOf":[
+              "parent_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The parent hash."
+                "description": "The parent hash."
               },
-              "protocol_version":{
-                "allOf":[
+              "protocol_version": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ProtocolVersion"
+                    "$ref": "#/components/schemas/ProtocolVersion"
                   }
                 ],
-                "description":"The protocol version."
+                "description": "The protocol version."
               },
-              "random_bit":{
-                "description":"Randomness bit.",
-                "type":"boolean"
+              "random_bit": {
+                "description": "Randomness bit.",
+                "type": "boolean"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"The state root hash."
+                "description": "The state root hash."
               },
-              "timestamp":{
-                "allOf":[
+              "timestamp": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Timestamp"
+                    "$ref": "#/components/schemas/Timestamp"
                   }
                 ],
-                "description":"The block timestamp."
+                "description": "The block timestamp."
               }
             },
-            "required":[
+            "required": [
               "accumulated_seed",
               "body_hash",
               "era_id",
@@ -1583,242 +1583,242 @@
               "state_root_hash",
               "timestamp"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonDelegator":{
-            "additionalProperties":false,
-            "description":"A delegator associated with the given validator.",
-            "properties":{
-              "bonding_purse":{
-                "$ref":"#/components/schemas/URef"
+          "JsonDelegator": {
+            "additionalProperties": false,
+            "description": "A delegator associated with the given validator.",
+            "properties": {
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "delegatee":{
-                "$ref":"#/components/schemas/PublicKey"
+              "delegatee": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "staked_amount":{
-                "$ref":"#/components/schemas/U512"
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegatee",
               "public_key",
               "staked_amount"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraChange":{
-            "additionalProperties":false,
-            "description":"A single change to a validator's status between two eras.",
-            "properties":{
-              "era_id":{
-                "allOf":[
+          "JsonEraChange": {
+            "additionalProperties": false,
+            "description": "A single change to a validator's status in the given era.",
+            "properties": {
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The era in which the change occurred."
+                "description": "The era in which the change occurred."
               },
-              "validator_change":{
-                "allOf":[
+              "validator_change": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ValidatorChange"
+                    "$ref": "#/components/schemas/ValidatorChange"
                   }
                 ],
-                "description":"The change in validator status."
+                "description": "The change in validator status."
               }
             },
-            "required":[
+            "required": [
               "era_id",
               "validator_change"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraEnd":{
-            "additionalProperties":false,
-            "properties":{
-              "era_report":{
-                "$ref":"#/components/schemas/JsonEraReport"
+          "JsonEraEnd": {
+            "additionalProperties": false,
+            "properties": {
+              "era_report": {
+                "$ref": "#/components/schemas/JsonEraReport"
               },
-              "next_era_validator_weights":{
-                "items":{
-                  "$ref":"#/components/schemas/ValidatorWeight"
+              "next_era_validator_weights": {
+                "items": {
+                  "$ref": "#/components/schemas/ValidatorWeight"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "era_report",
               "next_era_validator_weights"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraReport":{
-            "additionalProperties":false,
-            "description":"Equivocation and reward information to be included in the terminal block.",
-            "properties":{
-              "equivocators":{
-                "items":{
-                  "$ref":"#/components/schemas/PublicKey"
+          "JsonEraReport": {
+            "additionalProperties": false,
+            "description": "Equivocation and reward information to be included in the terminal block.",
+            "properties": {
+              "equivocators": {
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "inactive_validators":{
-                "items":{
-                  "$ref":"#/components/schemas/PublicKey"
+              "inactive_validators": {
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "rewards":{
-                "items":{
-                  "$ref":"#/components/schemas/Reward"
+              "rewards": {
+                "items": {
+                  "$ref": "#/components/schemas/Reward"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "equivocators",
               "inactive_validators",
               "rewards"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraValidators":{
-            "additionalProperties":false,
-            "description":"The validators for the given era.",
-            "properties":{
-              "era_id":{
-                "$ref":"#/components/schemas/EraId"
+          "JsonEraValidators": {
+            "additionalProperties": false,
+            "description": "The validators for the given era.",
+            "properties": {
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
               },
-              "validator_weights":{
-                "items":{
-                  "$ref":"#/components/schemas/JsonValidatorWeights"
+              "validator_weights": {
+                "items": {
+                  "$ref": "#/components/schemas/JsonValidatorWeights"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "era_id",
               "validator_weights"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonExecutionResult":{
-            "additionalProperties":false,
-            "description":"The execution result of a single deploy.",
-            "properties":{
-              "block_hash":{
-                "allOf":[
+          "JsonExecutionResult": {
+            "additionalProperties": false,
+            "description": "The execution result of a single deploy.",
+            "properties": {
+              "block_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The block hash."
+                "description": "The block hash."
               },
-              "result":{
-                "allOf":[
+              "result": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ExecutionResult"
+                    "$ref": "#/components/schemas/ExecutionResult"
                   }
                 ],
-                "description":"Execution result."
+                "description": "Execution result."
               }
             },
-            "required":[
+            "required": [
               "block_hash",
               "result"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonProof":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of a proof, i.e. a block's finality signature.",
-            "properties":{
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+          "JsonProof": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of a proof, i.e. a block's finality signature.",
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "signature":{
-                "$ref":"#/components/schemas/Signature"
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "signature"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonValidatorInfo":{
-            "additionalProperties":false,
-            "description":"The changes in a validator's status between any two eras.",
-            "properties":{
-              "public_key":{
-                "allOf":[
+          "JsonValidatorChanges": {
+            "additionalProperties": false,
+            "description": "The changes in a validator's status.",
+            "properties": {
+              "public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"The public key of a given validator."
+                "description": "The public key of the validator."
               },
-              "status_changes":{
-                "description":"The set of changes to the validator's status.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonEraChange"
+              "status_changes": {
+                "description": "The set of changes to the validator's status.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonEraChange"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "status_changes"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonValidatorWeights":{
-            "additionalProperties":false,
-            "description":"A validator's weight.",
-            "properties":{
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+          "JsonValidatorWeights": {
+            "additionalProperties": false,
+            "description": "A validator's weight.",
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "weight":{
-                "$ref":"#/components/schemas/U512"
+              "weight": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "MinimalBlockInfo":{
-            "additionalProperties":false,
-            "description":"Minimal info of a `Block`.",
-            "properties":{
-              "creator":{
-                "$ref":"#/components/schemas/PublicKey"
+          "MinimalBlockInfo": {
+            "additionalProperties": false,
+            "description": "Minimal info of a `Block`.",
+            "properties": {
+              "creator": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "era_id":{
-                "$ref":"#/components/schemas/EraId"
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
               },
-              "hash":{
-                "$ref":"#/components/schemas/BlockHash"
+              "hash": {
+                "$ref": "#/components/schemas/BlockHash"
               },
-              "height":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "height": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "state_root_hash":{
-                "$ref":"#/components/schemas/Digest"
+              "state_root_hash": {
+                "$ref": "#/components/schemas/Digest"
               },
-              "timestamp":{
-                "$ref":"#/components/schemas/Timestamp"
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
               }
             },
-            "required":[
+            "required": [
               "creator",
               "era_id",
               "hash",
@@ -1826,476 +1826,476 @@
               "state_root_hash",
               "timestamp"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "NamedArg":{
-            "description":"Named arguments to a contract",
-            "items":[
+          "NamedArg": {
+            "description": "Named arguments to a contract",
+            "items": [
               {
-                "type":"string"
+                "type": "string"
               },
               {
-                "$ref":"#/components/schemas/CLValue"
+                "$ref": "#/components/schemas/CLValue"
               }
             ],
-            "maxItems":2,
-            "minItems":2,
-            "type":"array"
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
           },
-          "NamedKey":{
-            "additionalProperties":false,
-            "description":"A named key.",
-            "properties":{
-              "key":{
-                "description":"The value of the entry: a casper `Key` type.",
-                "type":"string"
+          "NamedKey": {
+            "additionalProperties": false,
+            "description": "A named key.",
+            "properties": {
+              "key": {
+                "description": "The value of the entry: a casper `Key` type.",
+                "type": "string"
               },
-              "name":{
-                "description":"The name of the entry.",
-                "type":"string"
+              "name": {
+                "description": "The name of the entry.",
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "key",
               "name"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "NextUpgrade":{
-            "description":"Information about the next protocol upgrade.",
-            "properties":{
-              "activation_point":{
-                "$ref":"#/components/schemas/ActivationPoint"
+          "NextUpgrade": {
+            "description": "Information about the next protocol upgrade.",
+            "properties": {
+              "activation_point": {
+                "$ref": "#/components/schemas/ActivationPoint"
               },
-              "protocol_version":{
-                "type":"string"
+              "protocol_version": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "activation_point",
               "protocol_version"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "OpKind":{
-            "description":"The type of operation performed while executing a deploy.",
-            "enum":[
+          "OpKind": {
+            "description": "The type of operation performed while executing a deploy.",
+            "enum": [
               "Read",
               "Write",
               "Add",
               "NoOp"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "Operation":{
-            "additionalProperties":false,
-            "description":"An operation performed while executing a deploy.",
-            "properties":{
-              "key":{
-                "description":"The formatted string of the `Key`.",
-                "type":"string"
+          "Operation": {
+            "additionalProperties": false,
+            "description": "An operation performed while executing a deploy.",
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
               },
-              "kind":{
-                "allOf":[
+              "kind": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/OpKind"
+                    "$ref": "#/components/schemas/OpKind"
                   }
                 ],
-                "description":"The type of operation."
+                "description": "The type of operation."
               }
             },
-            "required":[
+            "required": [
               "key",
               "kind"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Parameter":{
-            "description":"Parameter to a method",
-            "properties":{
-              "cl_type":{
-                "$ref":"#/components/schemas/CLType"
+          "Parameter": {
+            "description": "Parameter to a method",
+            "properties": {
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
               },
-              "name":{
-                "type":"string"
+              "name": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "cl_type",
               "name"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "PeerEntry":{
-            "additionalProperties":false,
-            "properties":{
-              "address":{
-                "type":"string"
+          "PeerEntry": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "type": "string"
               },
-              "node_id":{
-                "type":"string"
+              "node_id": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "address",
               "node_id"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "PeersMap":{
-            "description":"Map of peer IDs to network addresses.",
-            "items":{
-              "$ref":"#/components/schemas/PeerEntry"
+          "PeersMap": {
+            "description": "Map of peer IDs to network addresses.",
+            "items": {
+              "$ref": "#/components/schemas/PeerEntry"
             },
-            "type":"array"
+            "type": "array"
           },
-          "ProtocolVersion":{
-            "description":"Casper Platform protocol version",
-            "type":"string"
+          "ProtocolVersion": {
+            "description": "Casper Platform protocol version",
+            "type": "string"
           },
-          "PublicKey":{
-            "description":"Hex-encoded cryptographic public key, including the algorithm tag prefix.",
-            "type":"string"
+          "PublicKey": {
+            "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+            "type": "string"
           },
-          "Reward":{
-            "additionalProperties":false,
-            "properties":{
-              "amount":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+          "Reward": {
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "validator":{
-                "$ref":"#/components/schemas/PublicKey"
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "amount",
               "validator"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "RuntimeArgs":{
-            "description":"Represents a collection of arguments passed to a smart contract.",
-            "items":{
-              "$ref":"#/components/schemas/NamedArg"
+          "RuntimeArgs": {
+            "description": "Represents a collection of arguments passed to a smart contract.",
+            "items": {
+              "$ref": "#/components/schemas/NamedArg"
             },
-            "type":"array"
+            "type": "array"
           },
-          "SeigniorageAllocation":{
-            "anyOf":[
+          "SeigniorageAllocation": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Info about a seigniorage allocation for a validator",
-                "properties":{
-                  "Validator":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "amount":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "Info about a seigniorage allocation for a validator",
+                "properties": {
+                  "Validator": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"Allocated amount"
+                        "description": "Allocated amount"
                       },
-                      "validator_public_key":{
-                        "allOf":[
+                      "validator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Validator's public key"
+                        "description": "Validator's public key"
                       }
                     },
-                    "required":[
+                    "required": [
                       "amount",
                       "validator_public_key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Validator"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Info about a seigniorage allocation for a delegator",
-                "properties":{
-                  "Delegator":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "amount":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "Info about a seigniorage allocation for a delegator",
+                "properties": {
+                  "Delegator": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"Allocated amount"
+                        "description": "Allocated amount"
                       },
-                      "delegator_public_key":{
-                        "allOf":[
+                      "delegator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Delegator's public key"
+                        "description": "Delegator's public key"
                       },
-                      "validator_public_key":{
-                        "allOf":[
+                      "validator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Validator's public key"
+                        "description": "Validator's public key"
                       }
                     },
-                    "required":[
+                    "required": [
                       "amount",
                       "delegator_public_key",
                       "validator_public_key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Delegator"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Information about a seigniorage allocation"
+            "description": "Information about a seigniorage allocation"
           },
-          "Signature":{
-            "description":"Hex-encoded cryptographic signature, including the algorithm tag prefix.",
-            "type":"string"
+          "Signature": {
+            "description": "Hex-encoded cryptographic signature, including the algorithm tag prefix.",
+            "type": "string"
           },
-          "StoredValue":{
-            "anyOf":[
+          "StoredValue": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"A CasperLabs value.",
-                "properties":{
-                  "CLValue":{
-                    "$ref":"#/components/schemas/CLValue"
+                "additionalProperties": false,
+                "description": "A CasperLabs value.",
+                "properties": {
+                  "CLValue": {
+                    "$ref": "#/components/schemas/CLValue"
                   }
                 },
-                "required":[
+                "required": [
                   "CLValue"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"An account.",
-                "properties":{
-                  "Account":{
-                    "$ref":"#/components/schemas/Account"
+                "additionalProperties": false,
+                "description": "An account.",
+                "properties": {
+                  "Account": {
+                    "$ref": "#/components/schemas/Account"
                   }
                 },
-                "required":[
+                "required": [
                   "Account"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A contract's Wasm",
-                "properties":{
-                  "ContractWasm":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "A contract's Wasm",
+                "properties": {
+                  "ContractWasm": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractWasm"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Methods and type signatures supported by a contract.",
-                "properties":{
-                  "Contract":{
-                    "$ref":"#/components/schemas/Contract"
+                "additionalProperties": false,
+                "description": "Methods and type signatures supported by a contract.",
+                "properties": {
+                  "Contract": {
+                    "$ref": "#/components/schemas/Contract"
                   }
                 },
-                "required":[
+                "required": [
                   "Contract"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A contract definition, metadata, and security container.",
-                "properties":{
-                  "ContractPackage":{
-                    "$ref":"#/components/schemas/ContractPackage"
+                "additionalProperties": false,
+                "description": "A contract definition, metadata, and security container.",
+                "properties": {
+                  "ContractPackage": {
+                    "$ref": "#/components/schemas/ContractPackage"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractPackage"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A record of a transfer",
-                "properties":{
-                  "Transfer":{
-                    "$ref":"#/components/schemas/Transfer"
+                "additionalProperties": false,
+                "description": "A record of a transfer",
+                "properties": {
+                  "Transfer": {
+                    "$ref": "#/components/schemas/Transfer"
                   }
                 },
-                "required":[
+                "required": [
                   "Transfer"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A record of a deploy",
-                "properties":{
-                  "DeployInfo":{
-                    "$ref":"#/components/schemas/DeployInfo"
+                "additionalProperties": false,
+                "description": "A record of a deploy",
+                "properties": {
+                  "DeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "DeployInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Auction metadata",
-                "properties":{
-                  "EraInfo":{
-                    "$ref":"#/components/schemas/EraInfo"
+                "additionalProperties": false,
+                "description": "Auction metadata",
+                "properties": {
+                  "EraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "EraInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A bid",
-                "properties":{
-                  "Bid":{
-                    "$ref":"#/components/schemas/Bid"
+                "additionalProperties": false,
+                "description": "A bid",
+                "properties": {
+                  "Bid": {
+                    "$ref": "#/components/schemas/Bid"
                   }
                 },
-                "required":[
+                "required": [
                   "Bid"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A withdraw",
-                "properties":{
-                  "Withdraw":{
-                    "items":{
-                      "$ref":"#/components/schemas/UnbondingPurse"
+                "additionalProperties": false,
+                "description": "A withdraw",
+                "properties": {
+                  "Withdraw": {
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Withdraw"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
+            "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
           },
-          "TimeDiff":{
-            "description":"Human-readable duration.",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "TimeDiff": {
+            "description": "Human-readable duration.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "Timestamp":{
-            "description":"Timestamp formatted as per RFC 3339",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "Timestamp": {
+            "description": "Timestamp formatted as per RFC 3339",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "Transfer":{
-            "additionalProperties":false,
-            "description":"Represents a transfer from one purse to another",
-            "properties":{
-              "amount":{
-                "allOf":[
+          "Transfer": {
+            "additionalProperties": false,
+            "description": "Represents a transfer from one purse to another",
+            "properties": {
+              "amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Transfer amount"
+                "description": "Transfer amount"
               },
-              "deploy_hash":{
-                "allOf":[
+              "deploy_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/DeployHash"
+                    "$ref": "#/components/schemas/DeployHash"
                   }
                 ],
-                "description":"Deploy that created the transfer"
+                "description": "Deploy that created the transfer"
               },
-              "from":{
-                "allOf":[
+              "from": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 ],
-                "description":"Account from which transfer was executed"
+                "description": "Account from which transfer was executed"
               },
-              "gas":{
-                "allOf":[
+              "gas": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Gas"
+                "description": "Gas"
               },
-              "id":{
-                "description":"User-defined id",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":[
+              "id": {
+                "description": "User-defined id",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": [
                   "integer",
                   "null"
                 ]
               },
-              "source":{
-                "allOf":[
+              "source": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Source purse"
+                "description": "Source purse"
               },
-              "target":{
-                "allOf":[
+              "target": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Target purse"
+                "description": "Target purse"
               },
-              "to":{
-                "anyOf":[
+              "to": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"Account to which funds are transferred"
+                "description": "Account to which funds are transferred"
               }
             },
-            "required":[
+            "required": [
               "amount",
               "deploy_hash",
               "from",
@@ -2303,429 +2303,429 @@
               "source",
               "target"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "TransferAddr":{
-            "description":"Hex-encoded transfer address.",
-            "type":"string"
+          "TransferAddr": {
+            "description": "Hex-encoded transfer address.",
+            "type": "string"
           },
-          "Transform":{
-            "anyOf":[
+          "Transform": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Identity",
                   "WriteContractWasm",
                   "WriteContract",
                   "WriteContractPackage"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given CLValue to global state.",
-                "properties":{
-                  "WriteCLValue":{
-                    "$ref":"#/components/schemas/CLValue"
+                "additionalProperties": false,
+                "description": "Writes the given CLValue to global state.",
+                "properties": {
+                  "WriteCLValue": {
+                    "$ref": "#/components/schemas/CLValue"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteCLValue"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Account to global state.",
-                "properties":{
-                  "WriteAccount":{
-                    "$ref":"#/components/schemas/AccountHash"
+                "additionalProperties": false,
+                "description": "Writes the given Account to global state.",
+                "properties": {
+                  "WriteAccount": {
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteAccount"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given DeployInfo to global state.",
-                "properties":{
-                  "WriteDeployInfo":{
-                    "$ref":"#/components/schemas/DeployInfo"
+                "additionalProperties": false,
+                "description": "Writes the given DeployInfo to global state.",
+                "properties": {
+                  "WriteDeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteDeployInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given EraInfo to global state.",
-                "properties":{
-                  "WriteEraInfo":{
-                    "$ref":"#/components/schemas/EraInfo"
+                "additionalProperties": false,
+                "description": "Writes the given EraInfo to global state.",
+                "properties": {
+                  "WriteEraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteEraInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Transfer to global state.",
-                "properties":{
-                  "WriteTransfer":{
-                    "$ref":"#/components/schemas/Transfer"
+                "additionalProperties": false,
+                "description": "Writes the given Transfer to global state.",
+                "properties": {
+                  "WriteTransfer": {
+                    "$ref": "#/components/schemas/Transfer"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteTransfer"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Bid to global state.",
-                "properties":{
-                  "WriteBid":{
-                    "$ref":"#/components/schemas/Bid"
+                "additionalProperties": false,
+                "description": "Writes the given Bid to global state.",
+                "properties": {
+                  "WriteBid": {
+                    "$ref": "#/components/schemas/Bid"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteBid"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Withdraw to global state.",
-                "properties":{
-                  "WriteWithdraw":{
-                    "items":{
-                      "$ref":"#/components/schemas/UnbondingPurse"
+                "additionalProperties": false,
+                "description": "Writes the given Withdraw to global state.",
+                "properties": {
+                  "WriteWithdraw": {
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteWithdraw"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `i32`.",
-                "properties":{
-                  "AddInt32":{
-                    "format":"int32",
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Adds the given `i32`.",
+                "properties": {
+                  "AddInt32": {
+                    "format": "int32",
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "AddInt32"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `u64`.",
-                "properties":{
-                  "AddUInt64":{
-                    "format":"uint64",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Adds the given `u64`.",
+                "properties": {
+                  "AddUInt64": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt64"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U128`.",
-                "properties":{
-                  "AddUInt128":{
-                    "$ref":"#/components/schemas/U128"
+                "additionalProperties": false,
+                "description": "Adds the given `U128`.",
+                "properties": {
+                  "AddUInt128": {
+                    "$ref": "#/components/schemas/U128"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt128"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U256`.",
-                "properties":{
-                  "AddUInt256":{
-                    "$ref":"#/components/schemas/U256"
+                "additionalProperties": false,
+                "description": "Adds the given `U256`.",
+                "properties": {
+                  "AddUInt256": {
+                    "$ref": "#/components/schemas/U256"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt256"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U512`.",
-                "properties":{
-                  "AddUInt512":{
-                    "$ref":"#/components/schemas/U512"
+                "additionalProperties": false,
+                "description": "Adds the given `U512`.",
+                "properties": {
+                  "AddUInt512": {
+                    "$ref": "#/components/schemas/U512"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt512"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given collection of named keys.",
-                "properties":{
-                  "AddKeys":{
-                    "items":{
-                      "$ref":"#/components/schemas/NamedKey"
+                "additionalProperties": false,
+                "description": "Adds the given collection of named keys.",
+                "properties": {
+                  "AddKeys": {
+                    "items": {
+                      "$ref": "#/components/schemas/NamedKey"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "AddKeys"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A failed transformation, containing an error message.",
-                "properties":{
-                  "Failure":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "A failed transformation, containing an error message.",
+                "properties": {
+                  "Failure": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "Failure"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"The actual transformation performed while executing a deploy."
+            "description": "The actual transformation performed while executing a deploy."
           },
-          "TransformEntry":{
-            "additionalProperties":false,
-            "description":"A transformation performed while executing a deploy.",
-            "properties":{
-              "key":{
-                "description":"The formatted string of the `Key`.",
-                "type":"string"
+          "TransformEntry": {
+            "additionalProperties": false,
+            "description": "A transformation performed while executing a deploy.",
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
               },
-              "transform":{
-                "allOf":[
+              "transform": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Transform"
+                    "$ref": "#/components/schemas/Transform"
                   }
                 ],
-                "description":"The transformation."
+                "description": "The transformation."
               }
             },
-            "required":[
+            "required": [
               "key",
               "transform"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "U128":{
-            "description":"Decimal representation of a 128-bit integer.",
-            "type":"string"
+          "U128": {
+            "description": "Decimal representation of a 128-bit integer.",
+            "type": "string"
           },
-          "U256":{
-            "description":"Decimal representation of a 256-bit integer.",
-            "type":"string"
+          "U256": {
+            "description": "Decimal representation of a 256-bit integer.",
+            "type": "string"
           },
-          "U512":{
-            "description":"Decimal representation of a 512-bit integer.",
-            "type":"string"
+          "U512": {
+            "description": "Decimal representation of a 512-bit integer.",
+            "type": "string"
           },
-          "URef":{
-            "description":"Hex-encoded, formatted URef.",
-            "type":"string"
+          "URef": {
+            "description": "Hex-encoded, formatted URef.",
+            "type": "string"
           },
-          "UnbondingPurse":{
-            "additionalProperties":false,
-            "description":"Unbonding purse.",
-            "properties":{
-              "amount":{
-                "allOf":[
+          "UnbondingPurse": {
+            "additionalProperties": false,
+            "description": "Unbonding purse.",
+            "properties": {
+              "amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Unbonding Amount."
+                "description": "Unbonding Amount."
               },
-              "bonding_purse":{
-                "allOf":[
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Bonding Purse"
+                "description": "Bonding Purse"
               },
-              "era_of_creation":{
-                "allOf":[
+              "era_of_creation": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"Era in which this unbonding request was created."
+                "description": "Era in which this unbonding request was created."
               },
-              "unbonder_public_key":{
-                "allOf":[
+              "unbonder_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Unbonders public key."
+                "description": "Unbonders public key."
               },
-              "validator_public_key":{
-                "allOf":[
+              "validator_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Validators public key."
+                "description": "Validators public key."
               }
             },
-            "required":[
+            "required": [
               "amount",
               "bonding_purse",
               "era_of_creation",
               "unbonder_public_key",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ValidatorChange":{
-            "description":"A change to a validator's status between two eras.",
-            "enum":[
+          "ValidatorChange": {
+            "description": "A change to a validator's status between two eras.",
+            "enum": [
               "Added",
               "Removed",
               "Banned",
               "CannotPropose",
               "SeenAsFaulty"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "ValidatorWeight":{
-            "additionalProperties":false,
-            "properties":{
-              "validator":{
-                "$ref":"#/components/schemas/PublicKey"
+          "ValidatorWeight": {
+            "additionalProperties": false,
+            "properties": {
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "weight":{
-                "$ref":"#/components/schemas/U512"
+              "weight": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "validator",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "VestingSchedule":{
-            "additionalProperties":false,
-            "properties":{
-              "initial_release_timestamp_millis":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+          "VestingSchedule": {
+            "additionalProperties": false,
+            "properties": {
+              "initial_release_timestamp_millis": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "locked_amounts":{
-                "items":{
-                  "$ref":"#/components/schemas/U512"
+              "locked_amounts": {
+                "items": {
+                  "$ref": "#/components/schemas/U512"
                 },
-                "maxItems":14,
-                "minItems":14,
-                "type":[
+                "maxItems": 14,
+                "minItems": 14,
+                "type": [
                   "array",
                   "null"
                 ]
               }
             },
-            "required":[
+            "required": [
               "initial_release_timestamp_millis"
             ],
-            "type":"object"
+            "type": "object"
           }
         }
       },
-      "info":{
-        "contact":{
-          "name":"CasperLabs",
-          "url":"https://casperlabs.io"
+      "info": {
+        "contact": {
+          "name": "CasperLabs",
+          "url": "https://casperlabs.io"
         },
-        "description":"This describes the JSON-RPC 2.0 API of a node on the Casper network.",
-        "license":{
-          "name":"CasperLabs Open Source License Version 1.0",
-          "url":"https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
+        "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
+        "license": {
+          "name": "CasperLabs Open Source License Version 1.0",
+          "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
-        "title":"Client API of Casper Node",
-        "version":"1.3.2"
+        "title": "Client API of Casper Node",
+        "version": "1.3.2"
       },
-      "methods":[
+      "methods": [
         {
-          "examples":[
+          "examples": [
             {
-              "name":"account_put_deploy_example",
-              "params":[
+              "name": "account_put_deploy_example",
+              "params": [
                 {
-                  "name":"deploy",
-                  "value":{
-                    "approvals":[
+                  "name": "deploy",
+                  "value": {
+                    "approvals": [
                       {
-                        "signature":"012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
-                        "signer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+                        "signature": "012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                       }
                     ],
-                    "hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
-                    "header":{
-                      "account":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "body_hash":"d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name":"casper-example",
-                      "dependencies":[
+                    "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
+                    "header": {
+                      "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
+                      "chain_name": "casper-example",
+                      "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price":1,
-                      "timestamp":"2020-11-17T00:39:24.072Z",
-                      "ttl":"1h"
+                      "gas_price": 1,
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h"
                     },
-                    "payment":{
-                      "StoredContractByName":{
-                        "args":[
+                    "payment": {
+                      "StoredContractByName": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ],
-                        "entry_point":"example-entry-point",
-                        "name":"casper-example"
+                        "entry_point": "example-entry-point",
+                        "name": "casper-example"
                       }
                     },
-                    "session":{
-                      "Transfer":{
-                        "args":[
+                    "session": {
+                      "Transfer": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ]
@@ -2734,145 +2734,145 @@
                   }
                 }
               ],
-              "result":{
-                "name":"account_put_deploy_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "deploy_hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
+              "result": {
+                "name": "account_put_deploy_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
             }
           ],
-          "name":"account_put_deploy",
-          "params":[
+          "name": "account_put_deploy",
+          "params": [
             {
-              "name":"deploy",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Deploy",
-                "description":"The `Deploy`."
+              "name": "deploy",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Deploy",
+                "description": "The `Deploy`."
               }
             }
           ],
-          "result":{
-            "name":"account_put_deploy_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"account_put_deploy\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "account_put_deploy_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"account_put_deploy\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "deploy_hash":{
-                  "$ref":"#/components/schemas/DeployHash",
-                  "description":"The deploy hash."
+                "deploy_hash": {
+                  "$ref": "#/components/schemas/DeployHash",
+                  "description": "The deploy hash."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "deploy_hash"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"receives a Deploy to be executed by the network"
+          "summary": "receives a Deploy to be executed by the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_deploy_example",
-              "params":[
+              "name": "info_get_deploy_example",
+              "params": [
                 {
-                  "name":"deploy_hash",
-                  "value":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
+                  "name": "deploy_hash",
+                  "value": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               ],
-              "result":{
-                "name":"info_get_deploy_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "deploy":{
-                    "approvals":[
+              "result": {
+                "name": "info_get_deploy_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "deploy": {
+                    "approvals": [
                       {
-                        "signature":"012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
-                        "signer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+                        "signature": "012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                       }
                     ],
-                    "hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
-                    "header":{
-                      "account":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "body_hash":"d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name":"casper-example",
-                      "dependencies":[
+                    "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
+                    "header": {
+                      "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
+                      "chain_name": "casper-example",
+                      "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price":1,
-                      "timestamp":"2020-11-17T00:39:24.072Z",
-                      "ttl":"1h"
+                      "gas_price": 1,
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h"
                     },
-                    "payment":{
-                      "StoredContractByName":{
-                        "args":[
+                    "payment": {
+                      "StoredContractByName": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ],
-                        "entry_point":"example-entry-point",
-                        "name":"casper-example"
+                        "entry_point": "example-entry-point",
+                        "name": "casper-example"
                       }
                     },
-                    "session":{
-                      "Transfer":{
-                        "args":[
+                    "session": {
+                      "Transfer": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ]
                       }
                     }
                   },
-                  "execution_results":[
+                  "execution_results": [
                     {
-                      "block_hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
-                      "result":{
-                        "Success":{
-                          "cost":"123456",
-                          "effect":{
-                            "operations":[
+                      "block_hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
+                      "result": {
+                        "Success": {
+                          "cost": "123456",
+                          "effect": {
+                            "operations": [
                               {
-                                "key":"account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
-                                "kind":"Write"
+                                "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+                                "kind": "Write"
                               },
                               {
-                                "key":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                                "kind":"Read"
+                                "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                                "kind": "Read"
                               }
                             ],
-                            "transforms":[
+                            "transforms": [
                               {
-                                "key":"uref-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb-007",
-                                "transform":{
-                                  "AddUInt64":8
+                                "key": "uref-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb-007",
+                                "transform": {
+                                  "AddUInt64": 8
                                 }
                               },
                               {
-                                "key":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                                "transform":"Identity"
+                                "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                                "transform": "Identity"
                               }
                             ]
                           },
-                          "transfers":[
+                          "transfers": [
                             "transfer-5959595959595959595959595959595959595959595959595959595959595959",
                             "transfer-8282828282828282828282828282828282828282828282828282828282828282"
                           ]
@@ -2884,567 +2884,551 @@
               }
             }
           ],
-          "name":"info_get_deploy",
-          "params":[
+          "name": "info_get_deploy",
+          "params": [
             {
-              "name":"deploy_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/DeployHash",
-                "description":"The deploy hash."
+              "name": "deploy_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/DeployHash",
+                "description": "The deploy hash."
               }
             }
           ],
-          "result":{
-            "name":"info_get_deploy_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_deploy\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "info_get_deploy_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_deploy\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "deploy":{
-                  "$ref":"#/components/schemas/Deploy",
-                  "description":"The deploy."
+                "deploy": {
+                  "$ref": "#/components/schemas/Deploy",
+                  "description": "The deploy."
                 },
-                "execution_results":{
-                  "description":"The map of block hash to execution result.",
-                  "items":{
-                    "$ref":"#/components/schemas/JsonExecutionResult"
+                "execution_results": {
+                  "description": "The map of block hash to execution result.",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonExecutionResult"
                   },
-                  "type":"array"
+                  "type": "array"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "deploy",
                 "execution_results"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a Deploy from the network"
+          "summary": "returns a Deploy from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_account_info_example",
-              "params":[
+              "name": "state_get_account_info_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 },
                 {
-                  "name":"public_key",
-                  "value":"013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
+                  "name": "public_key",
+                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                 }
               ],
-              "result":{
-                "name":"state_get_account_info_example_result",
-                "value":{
-                  "account":{
-                    "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                    "action_thresholds":{
-                      "deployment":1,
-                      "key_management":1
+              "result": {
+                "name": "state_get_account_info_example_result",
+                "value": {
+                  "account": {
+                    "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                    "action_thresholds": {
+                      "deployment": 1,
+                      "key_management": 1
                     },
-                    "associated_keys":[
+                    "associated_keys": [
                       {
-                        "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                        "weight":1
+                        "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                        "weight": 1
                       }
                     ],
-                    "main_purse":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                    "named_keys":[
-
-                    ]
+                    "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                    "named_keys": []
                   },
-                  "api_version":"1.3.2",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+                  "api_version": "1.3.2",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
           ],
-          "name":"state_get_account_info",
-          "params":[
+          "name": "state_get_account_info",
+          "params": [
             {
-              "name":"public_key",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/PublicKey",
-                "description":"The public key of the Account."
+              "name": "public_key",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/PublicKey",
+                "description": "The public key of the Account."
               }
             },
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "anyOf":[
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/BlockIdentifier"
+                    "$ref": "#/components/schemas/BlockIdentifier"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"The block identifier."
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_account_info_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_account_info\" RPC response.",
-              "properties":{
-                "account":{
-                  "$ref":"#/components/schemas/Account",
-                  "description":"The account."
+          "result": {
+            "name": "state_get_account_info_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_account_info\" RPC response.",
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account",
+                  "description": "The account."
                 },
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 }
               },
-              "required":[
+              "required": [
                 "account",
                 "api_version",
                 "merkle_proof"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an Account from the network"
+          "summary": "returns an Account from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_dictionary_item_example",
-              "params":[
+              "name": "state_get_dictionary_item_example",
+              "params": [
                 {
-                  "name":"dictionary_identifier",
-                  "value":{
-                    "URef":{
-                      "dictionary_item_key":"a_unique_entry_identifier",
-                      "seed_uref":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
+                  "name": "dictionary_identifier",
+                  "value": {
+                    "URef": {
+                      "dictionary_item_key": "a_unique_entry_identifier",
+                      "seed_uref": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
                     }
                   }
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_dictionary_item_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "dictionary_key":"dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "CLValue":{
-                      "bytes":"0100000000000000",
-                      "cl_type":"U64",
-                      "parsed":1
+              "result": {
+                "name": "state_get_dictionary_item_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "CLValue": {
+                      "bytes": "0100000000000000",
+                      "cl_type": "U64",
+                      "parsed": 1
                     }
                   }
                 }
               }
             }
           ],
-          "name":"state_get_dictionary_item",
-          "params":[
+          "name": "state_get_dictionary_item",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"Hash of the state root"
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "Hash of the state root"
               }
             },
             {
-              "name":"dictionary_identifier",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/DictionaryIdentifier",
-                "description":"The Dictionary query identifier."
+              "name": "dictionary_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/DictionaryIdentifier",
+                "description": "The Dictionary query identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_dictionary_item_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_dictionary_item\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_dictionary_item_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_dictionary_item\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "dictionary_key":{
-                  "description":"The key under which the value is stored.",
-                  "type":"string"
+                "dictionary_key": {
+                  "description": "The key under which the value is stored.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "dictionary_key",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an item from a Dictionary"
+          "summary": "returns an item from a Dictionary"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"query_global_state_example",
-              "params":[
+              "name": "query_global_state_example",
+              "params": [
                 {
-                  "name":"key",
-                  "value":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
+                  "name": "key",
+                  "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
                 },
                 {
-                  "name":"path",
-                  "value":[
-
-                  ]
+                  "name": "path",
+                  "value": []
                 },
                 {
-                  "name":"state_identifier",
-                  "value":{
-                    "BlockHash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "state_identifier",
+                  "value": {
+                    "BlockHash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 }
               ],
-              "result":{
-                "name":"query_global_state_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block_header":{
-                    "accumulated_seed":"ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
-                    "body_hash":"7c8b1a0fa3e3055909220d15e48b721d48904a23fb2e20fd428a8f119fba0a1a",
-                    "era_end":{
-                      "era_report":{
-                        "equivocators":[
+              "result": {
+                "name": "query_global_state_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block_header": {
+                    "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                    "body_hash": "7c8b1a0fa3e3055909220d15e48b721d48904a23fb2e20fd428a8f119fba0a1a",
+                    "era_end": {
+                      "era_report": {
+                        "equivocators": [
                           "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                         ],
-                        "inactive_validators":[
+                        "inactive_validators": [
                           "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                         ],
-                        "rewards":[
+                        "rewards": [
                           {
-                            "amount":1000,
-                            "validator":"018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                            "amount": 1000,
+                            "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
                           }
                         ]
                       },
-                      "next_era_validator_weights":[
+                      "next_era_validator_weights": [
                         {
-                          "validator":"016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
-                          "weight":"456"
+                          "validator": "016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
+                          "weight": "456"
                         },
                         {
-                          "validator":"018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
-                          "weight":"789"
+                          "validator": "018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
+                          "weight": "789"
                         },
                         {
-                          "validator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                          "weight":"123"
+                          "validator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                          "weight": "123"
                         }
                       ]
                     },
-                    "era_id":1,
-                    "height":10,
-                    "parent_hash":"0707070707070707070707070707070707070707070707070707070707070707",
-                    "protocol_version":"1.0.0",
-                    "random_bit":true,
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp":"2020-11-17T00:39:24.072Z"
+                    "era_id": 1,
+                    "height": 10,
+                    "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                    "protocol_version": "1.0.0",
+                    "random_bit": true,
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "timestamp": "2020-11-17T00:39:24.072Z"
                   },
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "Account":{
-                      "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                      "action_thresholds":{
-                        "deployment":1,
-                        "key_management":1
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "Account": {
+                      "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                      "action_thresholds": {
+                        "deployment": 1,
+                        "key_management": 1
                       },
-                      "associated_keys":[
+                      "associated_keys": [
                         {
-                          "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                          "weight":1
+                          "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                          "weight": 1
                         }
                       ],
-                      "main_purse":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                      "named_keys":[
-
-                      ]
+                      "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                      "named_keys": []
                     }
                   }
                 }
               }
             }
           ],
-          "name":"query_global_state",
-          "params":[
+          "name": "query_global_state",
+          "params": [
             {
-              "name":"state_identifier",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/GlobalStateIdentifier",
-                "description":"The identifier used for the query."
+              "name": "state_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/GlobalStateIdentifier",
+                "description": "The identifier used for the query."
               }
             },
             {
-              "name":"key",
-              "required":true,
-              "schema":{
-                "description":"`casper_types::Key` as formatted string.",
-                "type":"string"
+              "name": "key",
+              "required": true,
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
               }
             },
             {
-              "name":"path",
-              "required":false,
-              "schema":{
-                "default":[
-
-                ],
-                "description":"The path components starting from the key as base.",
-                "items":{
-                  "type":"string"
+              "name": "path",
+              "required": false,
+              "schema": {
+                "default": [],
+                "description": "The path components starting from the key as base.",
+                "items": {
+                  "type": "string"
                 },
-                "type":"array"
+                "type": "array"
               }
             }
           ],
-          "result":{
-            "name":"query_global_state_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"query_global_state\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "query_global_state_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"query_global_state\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block_header":{
-                  "anyOf":[
+                "block_header": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/JsonBlockHeader"
+                      "$ref": "#/components/schemas/JsonBlockHeader"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block header if a Block hash was provided."
+                  "description": "The block header if a Block hash was provided."
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"a query to global state using either a Block hash or state root hash"
+          "summary": "a query to global state using either a Block hash or state root hash"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_peers_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_peers_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "peers":[
+              "name": "info_get_peers_example",
+              "params": [],
+              "result": {
+                "name": "info_get_peers_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "peers": [
                     {
-                      "address":"127.0.0.1:54321",
-                      "node_id":"tls:0101..0101"
+                      "address": "127.0.0.1:54321",
+                      "node_id": "tls:0101..0101"
                     }
                   ]
                 }
               }
             }
           ],
-          "name":"info_get_peers",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_peers_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_peers\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_peers",
+          "params": [],
+          "result": {
+            "name": "info_get_peers_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_peers\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "peers":{
-                  "$ref":"#/components/schemas/PeersMap",
-                  "description":"The node ID and network address of each connected peer."
+                "peers": {
+                  "$ref": "#/components/schemas/PeersMap",
+                  "description": "The node ID and network address of each connected peer."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "peers"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a list of peers connected to the node"
+          "summary": "returns a list of peers connected to the node"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_status_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_status_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "build_version":"1.0.0-xxxxxxxxx@DEBUG",
-                  "chainspec_name":"casper-example",
-                  "last_added_block_info":{
-                    "creator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                    "era_id":1,
-                    "hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
-                    "height":10,
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp":"2020-11-17T00:39:24.072Z"
+              "name": "info_get_status_example",
+              "params": [],
+              "result": {
+                "name": "info_get_status_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "build_version": "1.0.0-xxxxxxxxx@DEBUG",
+                  "chainspec_name": "casper-example",
+                  "last_added_block_info": {
+                    "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                    "era_id": 1,
+                    "hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
+                    "height": 10,
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "timestamp": "2020-11-17T00:39:24.072Z"
                   },
-                  "next_upgrade":{
-                    "activation_point":42,
-                    "protocol_version":"2.0.1"
+                  "next_upgrade": {
+                    "activation_point": 42,
+                    "protocol_version": "2.0.1"
                   },
-                  "our_public_signing_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                  "peers":[
+                  "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                  "peers": [
                     {
-                      "address":"127.0.0.1:54321",
-                      "node_id":"tls:0101..0101"
+                      "address": "127.0.0.1:54321",
+                      "node_id": "tls:0101..0101"
                     }
                   ],
-                  "round_length":"1m 5s 536ms",
-                  "starting_state_root_hash":"0202020202020202020202020202020202020202020202020202020202020202",
-                  "uptime":"13s"
+                  "round_length": "1m 5s 536ms",
+                  "starting_state_root_hash": "0202020202020202020202020202020202020202020202020202020202020202",
+                  "uptime": "13s"
                 }
               }
             }
           ],
-          "name":"info_get_status",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_status_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_status\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_status",
+          "params": [],
+          "result": {
+            "name": "info_get_status_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_status\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "build_version":{
-                  "description":"The compiled node version.",
-                  "type":"string"
+                "build_version": {
+                  "description": "The compiled node version.",
+                  "type": "string"
                 },
-                "chainspec_name":{
-                  "description":"The chainspec name.",
-                  "type":"string"
+                "chainspec_name": {
+                  "description": "The chainspec name.",
+                  "type": "string"
                 },
-                "last_added_block_info":{
-                  "anyOf":[
+                "last_added_block_info": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/MinimalBlockInfo"
+                      "$ref": "#/components/schemas/MinimalBlockInfo"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The minimal info of the last block from the linear chain."
+                  "description": "The minimal info of the last block from the linear chain."
                 },
-                "next_upgrade":{
-                  "anyOf":[
+                "next_upgrade": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/NextUpgrade"
+                      "$ref": "#/components/schemas/NextUpgrade"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Information about the next scheduled upgrade."
+                  "description": "Information about the next scheduled upgrade."
                 },
-                "our_public_signing_key":{
-                  "anyOf":[
+                "our_public_signing_key": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/PublicKey"
+                      "$ref": "#/components/schemas/PublicKey"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Our public signing key."
+                  "description": "Our public signing key."
                 },
-                "peers":{
-                  "$ref":"#/components/schemas/PeersMap",
-                  "description":"The node ID and network address of each connected peer."
+                "peers": {
+                  "$ref": "#/components/schemas/PeersMap",
+                  "description": "The node ID and network address of each connected peer."
                 },
-                "round_length":{
-                  "anyOf":[
+                "round_length": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/TimeDiff"
+                      "$ref": "#/components/schemas/TimeDiff"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The next round length if this node is a validator."
+                  "description": "The next round length if this node is a validator."
                 },
-                "starting_state_root_hash":{
-                  "$ref":"#/components/schemas/Digest",
-                  "description":"The state root hash used at the start of the current session."
+                "starting_state_root_hash": {
+                  "$ref": "#/components/schemas/Digest",
+                  "description": "The state root hash used at the start of the current session."
                 },
-                "uptime":{
-                  "$ref":"#/components/schemas/TimeDiff",
-                  "description":"Time that passed since the node has started."
+                "uptime": {
+                  "$ref": "#/components/schemas/TimeDiff",
+                  "description": "Time that passed since the node has started."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "build_version",
                 "chainspec_name",
@@ -3452,29 +3436,27 @@
                 "starting_state_root_hash",
                 "uptime"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns the current status of the node"
+          "summary": "returns the current status of the node"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_validator_changes_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_validator_changes_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "changes_to_validators":[
+              "name": "info_get_validator_changes_example",
+              "params": [],
+              "result": {
+                "name": "info_get_validator_changes_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "changes": [
                     {
-                      "public_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "status_changes":[
+                      "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "status_changes": [
                         {
-                          "era_id":1,
-                          "validator_change":"Added"
+                          "era_id": 1,
+                          "validator_change": "Added"
                         }
                       ]
                     }
@@ -3483,109 +3465,105 @@
               }
             }
           ],
-          "name":"info_get_validator_changes",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_validator_changes_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for the \"info_get_validator_changes\" RPC.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_validator_changes",
+          "params": [],
+          "result": {
+            "name": "info_get_validator_changes_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for the \"info_get_validator_changes\" RPC.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "changes_to_validators":{
-                  "description":"The validator information.",
-                  "items":{
-                    "$ref":"#/components/schemas/JsonValidatorInfo"
+                "changes": {
+                  "description": "The validators' status changes.",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonValidatorChanges"
                   },
-                  "type":"array"
+                  "type": "array"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
-                "changes_to_validators"
+                "changes"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns changes in validator status between any two eras"
+          "summary": "returns status changes of active validators"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_block_example",
-              "params":[
+              "name": "chain_get_block_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_block_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block":{
-                    "body":{
-                      "deploy_hashes":[
+              "result": {
+                "name": "chain_get_block_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block": {
+                    "body": {
+                      "deploy_hashes": [
                         "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                       ],
-                      "proposer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "transfer_hashes":[
-
-                      ]
+                      "proposer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "transfer_hashes": []
                     },
-                    "hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
-                    "header":{
-                      "accumulated_seed":"ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
-                      "body_hash":"7c8b1a0fa3e3055909220d15e48b721d48904a23fb2e20fd428a8f119fba0a1a",
-                      "era_end":{
-                        "era_report":{
-                          "equivocators":[
+                    "hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
+                    "header": {
+                      "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                      "body_hash": "7c8b1a0fa3e3055909220d15e48b721d48904a23fb2e20fd428a8f119fba0a1a",
+                      "era_end": {
+                        "era_report": {
+                          "equivocators": [
                             "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                           ],
-                          "inactive_validators":[
+                          "inactive_validators": [
                             "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                           ],
-                          "rewards":[
+                          "rewards": [
                             {
-                              "amount":1000,
-                              "validator":"018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                              "amount": 1000,
+                              "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
                             }
                           ]
                         },
-                        "next_era_validator_weights":[
+                        "next_era_validator_weights": [
                           {
-                            "validator":"016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
-                            "weight":"456"
+                            "validator": "016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
+                            "weight": "456"
                           },
                           {
-                            "validator":"018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
-                            "weight":"789"
+                            "validator": "018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
+                            "weight": "789"
                           },
                           {
-                            "validator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                            "weight":"123"
+                            "validator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                            "weight": "123"
                           }
                         ]
                       },
-                      "era_id":1,
-                      "height":10,
-                      "parent_hash":"0707070707070707070707070707070707070707070707070707070707070707",
-                      "protocol_version":"1.0.0",
-                      "random_bit":true,
-                      "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                      "timestamp":"2020-11-17T00:39:24.072Z"
+                      "era_id": 1,
+                      "height": 10,
+                      "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                      "protocol_version": "1.0.0",
+                      "random_bit": true,
+                      "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                      "timestamp": "2020-11-17T00:39:24.072Z"
                     },
-                    "proofs":[
+                    "proofs": [
                       {
-                        "public_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                        "signature":"01d8bc9e4c1877dabe5f82c22bf7f53d6d652b3098fe10addf5c981f0f2171215c0e55f4b6aca1aa92f2ee6b1884e077a89557e6bc8cc7d6cfc1aa29b38e2b5704"
+                        "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                        "signature": "01d8bc9e4c1877dabe5f82c22bf7f53d6d652b3098fe10addf5c981f0f2171215c0e55f4b6aca1aa92f2ee6b1884e077a89557e6bc8cc7d6cfc1aa29b38e2b5704"
                       }
                     ]
                   }
@@ -3593,398 +3571,396 @@
               }
             }
           ],
-          "name":"chain_get_block",
-          "params":[
+          "name": "chain_get_block",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_block_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_block\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_block_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_block\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block":{
-                  "anyOf":[
+                "block": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/JsonBlock"
+                      "$ref": "#/components/schemas/JsonBlock"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block, if found."
+                  "description": "The block, if found."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a Block from the network"
+          "summary": "returns a Block from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_block_transfers_example",
-              "params":[
+              "name": "chain_get_block_transfers_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_block_transfers_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block_hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
-                  "transfers":[
+              "result": {
+                "name": "chain_get_block_transfers_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block_hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
+                  "transfers": [
                     {
-                      "amount":"0",
-                      "deploy_hash":"0000000000000000000000000000000000000000000000000000000000000000",
-                      "from":"account-hash-0000000000000000000000000000000000000000000000000000000000000000",
-                      "gas":"0",
-                      "id":null,
-                      "source":"uref-0000000000000000000000000000000000000000000000000000000000000000-000",
-                      "target":"uref-0000000000000000000000000000000000000000000000000000000000000000-000",
-                      "to":null
+                      "amount": "0",
+                      "deploy_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                      "from": "account-hash-0000000000000000000000000000000000000000000000000000000000000000",
+                      "gas": "0",
+                      "id": null,
+                      "source": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
+                      "target": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
+                      "to": null
                     }
                   ]
                 }
               }
             }
           ],
-          "name":"chain_get_block_transfers",
-          "params":[
+          "name": "chain_get_block_transfers",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_block_transfers_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_block_transfers\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_block_transfers_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_block_transfers\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block_hash":{
-                  "anyOf":[
+                "block_hash": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/BlockHash"
+                      "$ref": "#/components/schemas/BlockHash"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block hash, if found."
+                  "description": "The block hash, if found."
                 },
-                "transfers":{
-                  "description":"The block's transfers, if found.",
-                  "items":{
-                    "$ref":"#/components/schemas/Transfer"
+                "transfers": {
+                  "description": "The block's transfers, if found.",
+                  "items": {
+                    "$ref": "#/components/schemas/Transfer"
                   },
-                  "type":[
+                  "type": [
                     "array",
                     "null"
                   ]
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns all transfers for a Block from the network"
+          "summary": "returns all transfers for a Block from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_state_root_hash_example",
-              "params":[
+              "name": "chain_get_state_root_hash_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Height":10
+                  "name": "block_identifier",
+                  "value": {
+                    "Height": 10
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_state_root_hash_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808"
+              "result": {
+                "name": "chain_get_state_root_hash_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
             }
           ],
-          "name":"chain_get_state_root_hash",
-          "params":[
+          "name": "chain_get_state_root_hash",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_state_root_hash_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_state_root_hash\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_state_root_hash_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_state_root_hash\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "state_root_hash":{
-                  "anyOf":[
+                "state_root_hash": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/Digest"
+                      "$ref": "#/components/schemas/Digest"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Hex-encoded hash of the state root."
+                  "description": "Hex-encoded hash of the state root."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a state root hash at a given Block"
+          "summary": "returns a state root hash at a given Block"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_item_example",
-              "params":[
+              "name": "state_get_item_example",
+              "params": [
                 {
-                  "name":"key",
-                  "value":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
+                  "name": "key",
+                  "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
                 },
                 {
-                  "name":"path",
-                  "value":[
+                  "name": "path",
+                  "value": [
                     "inner"
                   ]
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_item_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "CLValue":{
-                      "bytes":"0100000000000000",
-                      "cl_type":"U64",
-                      "parsed":1
+              "result": {
+                "name": "state_get_item_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "CLValue": {
+                      "bytes": "0100000000000000",
+                      "cl_type": "U64",
+                      "parsed": 1
                     }
                   }
                 }
               }
             }
           ],
-          "name":"state_get_item",
-          "params":[
+          "name": "state_get_item",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"Hash of the state root."
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "Hash of the state root."
               }
             },
             {
-              "name":"key",
-              "required":true,
-              "schema":{
-                "description":"`casper_types::Key` as formatted string.",
-                "type":"string"
+              "name": "key",
+              "required": true,
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
               }
             },
             {
-              "name":"path",
-              "required":false,
-              "schema":{
-                "default":[
-
-                ],
-                "description":"The path components starting from the key as base.",
-                "items":{
-                  "type":"string"
+              "name": "path",
+              "required": false,
+              "schema": {
+                "default": [],
+                "description": "The path components starting from the key as base.",
+                "items": {
+                  "type": "string"
                 },
-                "type":"array"
+                "type": "array"
               }
             }
           ],
-          "result":{
-            "name":"state_get_item_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_item\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_item_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_item\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead."
+          "summary": "returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead."
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_balance_example",
-              "params":[
+              "name": "state_get_balance_example",
+              "params": [
                 {
-                  "name":"purse_uref",
-                  "value":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
+                  "name": "purse_uref",
+                  "value": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_balance_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "balance_value":"123456",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+              "result": {
+                "name": "state_get_balance_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "balance_value": "123456",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
           ],
-          "name":"state_get_balance",
-          "params":[
+          "name": "state_get_balance",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"The hash of state root."
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "The hash of state root."
               }
             },
             {
-              "name":"purse_uref",
-              "required":true,
-              "schema":{
-                "description":"Formatted URef.",
-                "type":"string"
+              "name": "purse_uref",
+              "required": true,
+              "schema": {
+                "description": "Formatted URef.",
+                "type": "string"
               }
             }
           ],
-          "result":{
-            "name":"state_get_balance_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_balance\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_balance_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_balance\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "balance_value":{
-                  "$ref":"#/components/schemas/U512",
-                  "description":"The balance value."
+                "balance_value": {
+                  "$ref": "#/components/schemas/U512",
+                  "description": "The balance value."
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "balance_value",
                 "merkle_proof"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a purse's balance from the network"
+          "summary": "returns a purse's balance from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_era_info_by_switch_block_example",
-              "params":[
+              "name": "chain_get_era_info_by_switch_block_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_era_info_by_switch_block_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "era_summary":{
-                    "block_hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
-                    "era_id":42,
-                    "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "stored_value":{
-                      "EraInfo":{
-                        "seigniorage_allocations":[
+              "result": {
+                "name": "chain_get_era_info_by_switch_block_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "era_summary": {
+                    "block_hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e",
+                    "era_id": 42,
+                    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "stored_value": {
+                      "EraInfo": {
+                        "seigniorage_allocations": [
                           {
-                            "Delegator":{
-                              "amount":"1000",
-                              "delegator_public_key":"01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18",
-                              "validator_public_key":"012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                            "Delegator": {
+                              "amount": "1000",
+                              "delegator_public_key": "01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18",
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
                             }
                           },
                           {
-                            "Validator":{
-                              "amount":"2000",
-                              "validator_public_key":"012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                            "Validator": {
+                              "amount": "2000",
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
                             }
                           }
                         ]
@@ -3995,206 +3971,204 @@
               }
             }
           ],
-          "name":"chain_get_era_info_by_switch_block",
-          "params":[
+          "name": "chain_get_era_info_by_switch_block",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block identifier."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_era_info_by_switch_block_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_era_info\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_era_info_by_switch_block_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_era_info\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "era_summary":{
-                  "anyOf":[
+                "era_summary": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/EraSummary"
+                      "$ref": "#/components/schemas/EraSummary"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The era summary."
+                  "description": "The era summary."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an EraInfo from the network"
+          "summary": "returns an EraInfo from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_auction_info_example",
-              "params":[
+              "name": "state_get_auction_info_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "be8a9e156a89deca32f6322c5546738f3b9f5c62c5945a044d7043bc814f156e"
                   }
                 }
               ],
-              "result":{
-                "name":"state_get_auction_info_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "auction_state":{
-                    "bids":[
+              "result": {
+                "name": "state_get_auction_info_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "auction_state": {
+                    "bids": [
                       {
-                        "bid":{
-                          "bonding_purse":"uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
-                          "delegation_rate":0,
-                          "delegators":[
-
-                          ],
-                          "inactive":false,
-                          "staked_amount":"10"
+                        "bid": {
+                          "bonding_purse": "uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
+                          "delegation_rate": 0,
+                          "delegators": [],
+                          "inactive": false,
+                          "staked_amount": "10"
                         },
-                        "public_key":"01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
+                        "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
                       }
                     ],
-                    "block_height":10,
-                    "era_validators":[
+                    "block_height": 10,
+                    "era_validators": [
                       {
-                        "era_id":10,
-                        "validator_weights":[
+                        "era_id": 10,
+                        "validator_weights": [
                           {
-                            "public_key":"01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
-                            "weight":"10"
+                            "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+                            "weight": "10"
                           }
                         ]
                       }
                     ],
-                    "state_root_hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+                    "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
                   }
                 }
               }
             }
           ],
-          "name":"state_get_auction_info",
-          "params":[
+          "name": "state_get_auction_info",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block identifier."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_auction_info_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_auction_info\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_auction_info_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_auction_info\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "auction_state":{
-                  "$ref":"#/components/schemas/AuctionState",
-                  "description":"The auction state."
+                "auction_state": {
+                  "$ref": "#/components/schemas/AuctionState",
+                  "description": "The auction state."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "auction_state"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns the bids and validators as of either a specific block (by height or hash), or the most recently added block"
+          "summary": "returns the bids and validators as of either a specific block (by height or hash), or the most recently added block"
         }
       ],
-      "openrpc":"1.0.0-rc1",
-      "servers":[
+      "openrpc": "1.0.0-rc1",
+      "servers": [
         {
-          "name":"any Casper Network node",
-          "url":"http://IP:PORT/rpc/"
+          "name": "any Casper Network node",
+          "url": "http://IP:PORT/rpc/"
         }
       ]
     }
   ],
-  "type":"object",
-  "properties":{
-    "openrpc":{
-      "type":"string"
+  "type": "object",
+  "properties": {
+    "openrpc": {
+      "type": "string"
     },
-    "info":{
-      "type":"object",
-      "properties":{
-        "version":{
-          "type":"string"
+    "info": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
         },
-        "title":{
-          "type":"string"
+        "title": {
+          "type": "string"
         },
-        "description":{
-          "type":"string"
+        "description": {
+          "type": "string"
         },
-        "contact":{
-          "type":"object",
-          "properties":{
-            "name":{
-              "type":"string"
+        "contact": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "url":{
-              "type":"string"
+            "url": {
+              "type": "string"
             }
           }
         },
-        "license":{
-          "type":"object",
-          "properties":{
-            "name":{
-              "type":"string"
+        "license": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "url":{
-              "type":"string"
+            "url": {
+              "type": "string"
             }
           }
         }
       }
     },
-    "servers":{
-      "type":"array",
-      "items":{
-        "type":"object",
-        "properties":{
-          "name":{
-            "type":"string"
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "url":{
-            "type":"string"
+          "url": {
+            "type": "string"
           }
         }
       }
     },
-    "methods":{
-      "type":"array",
-      "items":true
+    "methods": {
+      "type": "array",
+      "items": true
     },
-    "components":{
-      "type":"object",
-      "properties":{
-        "schemas":{
-          "type":"object",
-          "additionalProperties":true
+    "components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     }

--- a/resources/test/rpc_schema_hashing_V1.json
+++ b/resources/test/rpc_schema_hashing_V1.json
@@ -1610,7 +1610,7 @@
             ],
             "type": "object"
           },
-          "JsonEraChange": {
+          "JsonValidatorStatusChange": {
             "additionalProperties": false,
             "description": "A single change to a validator's status in the given era.",
             "properties": {
@@ -1765,7 +1765,7 @@
               "status_changes": {
                 "description": "The set of changes to the validator's status.",
                 "items": {
-                  "$ref": "#/components/schemas/JsonEraChange"
+                  "$ref": "#/components/schemas/JsonValidatorStatusChange"
                 },
                 "type": "array"
               }

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -1,215 +1,215 @@
 {
-  "$schema":"http://json-schema.org/draft-07/schema#",
-  "title":"OpenRpcSchema",
-  "examples":[
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenRpcSchema",
+  "examples": [
     {
-      "components":{
-        "schemas":{
-          "Account":{
-            "additionalProperties":false,
-            "description":"Structure representing a user's account, stored in global state.",
-            "properties":{
-              "account_hash":{
-                "$ref":"#/components/schemas/AccountHash"
+      "components": {
+        "schemas": {
+          "Account": {
+            "additionalProperties": false,
+            "description": "Structure representing a user's account, stored in global state.",
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
               },
-              "action_thresholds":{
-                "$ref":"#/components/schemas/ActionThresholds"
+              "action_thresholds": {
+                "$ref": "#/components/schemas/ActionThresholds"
               },
-              "associated_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/AssociatedKey"
+              "associated_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/AssociatedKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "main_purse":{
-                "$ref":"#/components/schemas/URef"
+              "main_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "named_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/NamedKey"
+              "named_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "account_hash",
               "action_thresholds",
               "associated_keys",
               "main_purse",
               "named_keys"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AccountHash":{
-            "description":"Hex-encoded account hash.",
-            "type":"string"
+          "AccountHash": {
+            "description": "Hex-encoded account hash.",
+            "type": "string"
           },
-          "ActionThresholds":{
-            "additionalProperties":false,
-            "description":"Thresholds that have to be met when executing an action of a certain type.",
-            "properties":{
-              "deployment":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+          "ActionThresholds": {
+            "additionalProperties": false,
+            "description": "Thresholds that have to be met when executing an action of a certain type.",
+            "properties": {
+              "deployment": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "key_management":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "key_management": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "deployment",
               "key_management"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ActivationPoint":{
-            "anyOf":[
+          "ActivationPoint": {
+            "anyOf": [
               {
-                "$ref":"#/components/schemas/EraId"
+                "$ref": "#/components/schemas/EraId"
               },
               {
-                "$ref":"#/components/schemas/Timestamp"
+                "$ref": "#/components/schemas/Timestamp"
               }
             ],
-            "description":"The first era to which the associated protocol version applies."
+            "description": "The first era to which the associated protocol version applies."
           },
-          "Approval":{
-            "additionalProperties":false,
-            "description":"A struct containing a signature and the public key of the signer.",
-            "properties":{
-              "signature":{
-                "$ref":"#/components/schemas/Signature"
+          "Approval": {
+            "additionalProperties": false,
+            "description": "A struct containing a signature and the public key of the signer.",
+            "properties": {
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
               },
-              "signer":{
-                "$ref":"#/components/schemas/PublicKey"
+              "signer": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "signature",
               "signer"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AssociatedKey":{
-            "additionalProperties":false,
-            "properties":{
-              "account_hash":{
-                "$ref":"#/components/schemas/AccountHash"
+          "AssociatedKey": {
+            "additionalProperties": false,
+            "properties": {
+              "account_hash": {
+                "$ref": "#/components/schemas/AccountHash"
               },
-              "weight":{
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "weight": {
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "account_hash",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "AuctionState":{
-            "additionalProperties":false,
-            "description":"Data structure summarizing auction contract data.",
-            "properties":{
-              "bids":{
-                "description":"All bids contained within a vector.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonBids"
+          "AuctionState": {
+            "additionalProperties": false,
+            "description": "Data structure summarizing auction contract data.",
+            "properties": {
+              "bids": {
+                "description": "All bids contained within a vector.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonBids"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "block_height":{
-                "description":"Block height.",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "block_height": {
+                "description": "Block height.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "era_validators":{
-                "description":"Era validators.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonEraValidators"
+              "era_validators": {
+                "description": "Era validators.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonEraValidators"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Global state hash."
+                "description": "Global state hash."
               }
             },
-            "required":[
+            "required": [
               "bids",
               "block_height",
               "era_validators",
               "state_root_hash"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Bid":{
-            "additionalProperties":false,
-            "description":"An entry in the validator map.",
-            "properties":{
-              "bonding_purse":{
-                "allOf":[
+          "Bid": {
+            "additionalProperties": false,
+            "description": "An entry in the validator map.",
+            "properties": {
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"The purse that was used for bonding."
+                "description": "The purse that was used for bonding."
               },
-              "delegation_rate":{
-                "description":"Delegation rate",
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "delegation_rate": {
+                "description": "Delegation rate",
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "delegators":{
-                "additionalProperties":{
-                  "$ref":"#/components/schemas/Delegator"
+              "delegators": {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Delegator"
                 },
-                "description":"This validator's delegators, indexed by their public keys",
-                "type":"object"
+                "description": "This validator's delegators, indexed by their public keys",
+                "type": "object"
               },
-              "inactive":{
-                "description":"`true` if validator has been \"evicted\"",
-                "type":"boolean"
+              "inactive": {
+                "description": "`true` if validator has been \"evicted\"",
+                "type": "boolean"
               },
-              "staked_amount":{
-                "allOf":[
+              "staked_amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"The amount of tokens staked by a validator (not including delegators)."
+                "description": "The amount of tokens staked by a validator (not including delegators)."
               },
-              "validator_public_key":{
-                "allOf":[
+              "validator_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Validator public key"
+                "description": "Validator public key"
               },
-              "vesting_schedule":{
-                "anyOf":[
+              "vesting_schedule": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/VestingSchedule"
+                    "$ref": "#/components/schemas/VestingSchedule"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"Vesting schedule for a genesis validator. `None` if non-genesis validator."
+                "description": "Vesting schedule for a genesis validator. `None` if non-genesis validator."
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegation_rate",
               "delegators",
@@ -217,53 +217,53 @@
               "staked_amount",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "BlockHash":{
-            "allOf":[
+          "BlockHash": {
+            "allOf": [
               {
-                "$ref":"#/components/schemas/Digest"
+                "$ref": "#/components/schemas/Digest"
               }
             ],
-            "description":"A cryptographic hash identifying a [`Block`](struct.Block.html)."
+            "description": "A cryptographic hash identifying a [`Block`](struct.Block.html)."
           },
-          "BlockIdentifier":{
-            "anyOf":[
+          "BlockIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Identify and retrieve the block with its hash.",
-                "properties":{
-                  "Hash":{
-                    "$ref":"#/components/schemas/BlockHash"
+                "additionalProperties": false,
+                "description": "Identify and retrieve the block with its hash.",
+                "properties": {
+                  "Hash": {
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 },
-                "required":[
+                "required": [
                   "Hash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Identify and retrieve the block with its height.",
-                "properties":{
-                  "Height":{
-                    "format":"uint64",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Identify and retrieve the block with its height.",
+                "properties": {
+                  "Height": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "Height"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Identifier for possible ways to retrieve a block."
+            "description": "Identifier for possible ways to retrieve a block."
           },
-          "CLType":{
-            "anyOf":[
+          "CLType": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Bool",
                   "I32",
                   "I64",
@@ -280,387 +280,387 @@
                   "PublicKey",
                   "Any"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"`Option` of a `CLType`.",
-                "properties":{
-                  "Option":{
-                    "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "`Option` of a `CLType`.",
+                "properties": {
+                  "Option": {
+                    "$ref": "#/components/schemas/CLType"
                   }
                 },
-                "required":[
+                "required": [
                   "Option"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Variable-length list of a single `CLType` (comparable to a `Vec`).",
-                "properties":{
-                  "List":{
-                    "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "Variable-length list of a single `CLType` (comparable to a `Vec`).",
+                "properties": {
+                  "List": {
+                    "$ref": "#/components/schemas/CLType"
                   }
                 },
-                "required":[
+                "required": [
                   "List"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Fixed-length list of a single `CLType` (comparable to a Rust array).",
-                "properties":{
-                  "ByteArray":{
-                    "format":"uint32",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Fixed-length list of a single `CLType` (comparable to a Rust array).",
+                "properties": {
+                  "ByteArray": {
+                    "format": "uint32",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "ByteArray"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"`Result` with `Ok` and `Err` variants of `CLType`s.",
-                "properties":{
-                  "Result":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "err":{
-                        "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "`Result` with `Ok` and `Err` variants of `CLType`s.",
+                "properties": {
+                  "Result": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "err": {
+                        "$ref": "#/components/schemas/CLType"
                       },
-                      "ok":{
-                        "$ref":"#/components/schemas/CLType"
+                      "ok": {
+                        "$ref": "#/components/schemas/CLType"
                       }
                     },
-                    "required":[
+                    "required": [
                       "err",
                       "ok"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Result"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Map with keys of a single `CLType` and values of a single `CLType`.",
-                "properties":{
-                  "Map":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "key":{
-                        "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "Map with keys of a single `CLType` and values of a single `CLType`.",
+                "properties": {
+                  "Map": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "$ref": "#/components/schemas/CLType"
                       },
-                      "value":{
-                        "$ref":"#/components/schemas/CLType"
+                      "value": {
+                        "$ref": "#/components/schemas/CLType"
                       }
                     },
-                    "required":[
+                    "required": [
                       "key",
                       "value"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Map"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"1-ary tuple of a `CLType`.",
-                "properties":{
-                  "Tuple1":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "1-ary tuple of a `CLType`.",
+                "properties": {
+                  "Tuple1": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":1,
-                    "minItems":1,
-                    "type":"array"
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple1"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"2-ary tuple of `CLType`s.",
-                "properties":{
-                  "Tuple2":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "2-ary tuple of `CLType`s.",
+                "properties": {
+                  "Tuple2": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":2,
-                    "minItems":2,
-                    "type":"array"
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple2"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"3-ary tuple of `CLType`s.",
-                "properties":{
-                  "Tuple3":{
-                    "items":{
-                      "$ref":"#/components/schemas/CLType"
+                "additionalProperties": false,
+                "description": "3-ary tuple of `CLType`s.",
+                "properties": {
+                  "Tuple3": {
+                    "items": {
+                      "$ref": "#/components/schemas/CLType"
                     },
-                    "maxItems":3,
-                    "minItems":3,
-                    "type":"array"
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Tuple3"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue)."
+            "description": "Casper types, i.e. types which can be stored and manipulated by smart contracts.\n\nProvides a description of the underlying data type of a [`CLValue`](crate::CLValue)."
           },
-          "CLValue":{
-            "additionalProperties":false,
-            "description":"A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
-            "properties":{
-              "bytes":{
-                "type":"string"
+          "CLValue": {
+            "additionalProperties": false,
+            "description": "A Casper value, i.e. a value which can be stored and manipulated by smart contracts.\n\nIt holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member.\n\nThe `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.",
+            "properties": {
+              "bytes": {
+                "type": "string"
               },
-              "cl_type":{
-                "$ref":"#/components/schemas/CLType"
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
               },
-              "parsed":true
+              "parsed": true
             },
-            "required":[
+            "required": [
               "bytes",
               "cl_type"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Contract":{
-            "additionalProperties":false,
-            "description":"A contract struct that can be serialized as  JSON object.",
-            "properties":{
-              "contract_package_hash":{
-                "$ref":"#/components/schemas/ContractPackageHash"
+          "Contract": {
+            "additionalProperties": false,
+            "description": "A contract struct that can be serialized as  JSON object.",
+            "properties": {
+              "contract_package_hash": {
+                "$ref": "#/components/schemas/ContractPackageHash"
               },
-              "contract_wasm_hash":{
-                "$ref":"#/components/schemas/ContractWasmHash"
+              "contract_wasm_hash": {
+                "$ref": "#/components/schemas/ContractWasmHash"
               },
-              "entry_points":{
-                "items":{
-                  "$ref":"#/components/schemas/EntryPoint"
+              "entry_points": {
+                "items": {
+                  "$ref": "#/components/schemas/EntryPoint"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "named_keys":{
-                "items":{
-                  "$ref":"#/components/schemas/NamedKey"
+              "named_keys": {
+                "items": {
+                  "$ref": "#/components/schemas/NamedKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "protocol_version":{
-                "type":"string"
+              "protocol_version": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "contract_package_hash",
               "contract_wasm_hash",
               "entry_points",
               "named_keys",
               "protocol_version"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractHash":{
-            "description":"The hash address of the contract",
-            "type":"string"
+          "ContractHash": {
+            "description": "The hash address of the contract",
+            "type": "string"
           },
-          "ContractPackage":{
-            "additionalProperties":false,
-            "description":"Contract definition, metadata, and security container.",
-            "properties":{
-              "access_key":{
-                "$ref":"#/components/schemas/URef"
+          "ContractPackage": {
+            "additionalProperties": false,
+            "description": "Contract definition, metadata, and security container.",
+            "properties": {
+              "access_key": {
+                "$ref": "#/components/schemas/URef"
               },
-              "disabled_versions":{
-                "items":{
-                  "$ref":"#/components/schemas/DisabledVersion"
+              "disabled_versions": {
+                "items": {
+                  "$ref": "#/components/schemas/DisabledVersion"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "groups":{
-                "items":{
-                  "$ref":"#/components/schemas/Groups"
+              "groups": {
+                "items": {
+                  "$ref": "#/components/schemas/Groups"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "versions":{
-                "items":{
-                  "$ref":"#/components/schemas/ContractVersion"
+              "versions": {
+                "items": {
+                  "$ref": "#/components/schemas/ContractVersion"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "access_key",
               "disabled_versions",
               "groups",
               "versions"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractPackageHash":{
-            "description":"The hash address of the contract package",
-            "type":"string"
+          "ContractPackageHash": {
+            "description": "The hash address of the contract package",
+            "type": "string"
           },
-          "ContractVersion":{
-            "properties":{
-              "contract_hash":{
-                "$ref":"#/components/schemas/ContractHash"
+          "ContractVersion": {
+            "properties": {
+              "contract_hash": {
+                "$ref": "#/components/schemas/ContractHash"
               },
-              "contract_version":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "contract_version": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "protocol_version_major":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "protocol_version_major": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "contract_hash",
               "contract_version",
               "protocol_version_major"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ContractWasmHash":{
-            "description":"The hash address of the contract wasm",
-            "type":"string"
+          "ContractWasmHash": {
+            "description": "The hash address of the contract wasm",
+            "type": "string"
           },
-          "Delegator":{
-            "additionalProperties":false,
-            "description":"Represents a party delegating their stake to a validator (or \"delegatee\")",
-            "properties":{
-              "bonding_purse":{
-                "$ref":"#/components/schemas/URef"
+          "Delegator": {
+            "additionalProperties": false,
+            "description": "Represents a party delegating their stake to a validator (or \"delegatee\")",
+            "properties": {
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "delegator_public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "delegator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "staked_amount":{
-                "$ref":"#/components/schemas/U512"
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
               },
-              "validator_public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "validator_public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "vesting_schedule":{
-                "anyOf":[
+              "vesting_schedule": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/VestingSchedule"
+                    "$ref": "#/components/schemas/VestingSchedule"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ]
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegator_public_key",
               "staked_amount",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Deploy":{
-            "additionalProperties":false,
-            "description":"A deploy; an item containing a smart contract along with the requester's signature(s).",
-            "properties":{
-              "approvals":{
-                "items":{
-                  "$ref":"#/components/schemas/Approval"
+          "Deploy": {
+            "additionalProperties": false,
+            "description": "A deploy; an item containing a smart contract along with the requester's signature(s).",
+            "properties": {
+              "approvals": {
+                "items": {
+                  "$ref": "#/components/schemas/Approval"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "hash":{
-                "$ref":"#/components/schemas/DeployHash"
+              "hash": {
+                "$ref": "#/components/schemas/DeployHash"
               },
-              "header":{
-                "$ref":"#/components/schemas/DeployHeader"
+              "header": {
+                "$ref": "#/components/schemas/DeployHeader"
               },
-              "payment":{
-                "$ref":"#/components/schemas/ExecutableDeployItem"
+              "payment": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
               },
-              "session":{
-                "$ref":"#/components/schemas/ExecutableDeployItem"
+              "session": {
+                "$ref": "#/components/schemas/ExecutableDeployItem"
               }
             },
-            "required":[
+            "required": [
               "approvals",
               "hash",
               "header",
               "payment",
               "session"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DeployHash":{
-            "allOf":[
+          "DeployHash": {
+            "allOf": [
               {
-                "$ref":"#/components/schemas/Digest"
+                "$ref": "#/components/schemas/Digest"
               }
             ],
-            "description":"Hex-encoded deploy hash."
+            "description": "Hex-encoded deploy hash."
           },
-          "DeployHeader":{
-            "additionalProperties":false,
-            "description":"The header portion of a [`Deploy`](struct.Deploy.html).",
-            "properties":{
-              "account":{
-                "$ref":"#/components/schemas/PublicKey"
+          "DeployHeader": {
+            "additionalProperties": false,
+            "description": "The header portion of a [`Deploy`](struct.Deploy.html).",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "body_hash":{
-                "$ref":"#/components/schemas/Digest"
+              "body_hash": {
+                "$ref": "#/components/schemas/Digest"
               },
-              "chain_name":{
-                "type":"string"
+              "chain_name": {
+                "type": "string"
               },
-              "dependencies":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+              "dependencies": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "gas_price":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "gas_price": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "timestamp":{
-                "$ref":"#/components/schemas/Timestamp"
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
               },
-              "ttl":{
-                "$ref":"#/components/schemas/TimeDiff"
+              "ttl": {
+                "$ref": "#/components/schemas/TimeDiff"
               }
             },
-            "required":[
+            "required": [
               "account",
               "body_hash",
               "chain_name",
@@ -669,910 +669,910 @@
               "timestamp",
               "ttl"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DeployInfo":{
-            "additionalProperties":false,
-            "description":"Information relating to the given Deploy.",
-            "properties":{
-              "deploy_hash":{
-                "allOf":[
+          "DeployInfo": {
+            "additionalProperties": false,
+            "description": "Information relating to the given Deploy.",
+            "properties": {
+              "deploy_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/DeployHash"
+                    "$ref": "#/components/schemas/DeployHash"
                   }
                 ],
-                "description":"The relevant Deploy."
+                "description": "The relevant Deploy."
               },
-              "from":{
-                "allOf":[
+              "from": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 ],
-                "description":"Account identifier of the creator of the Deploy."
+                "description": "Account identifier of the creator of the Deploy."
               },
-              "gas":{
-                "allOf":[
+              "gas": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Gas cost of executing the Deploy."
+                "description": "Gas cost of executing the Deploy."
               },
-              "source":{
-                "allOf":[
+              "source": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Source purse used for payment of the Deploy."
+                "description": "Source purse used for payment of the Deploy."
               },
-              "transfers":{
-                "description":"Transfers performed by the Deploy.",
-                "items":{
-                  "$ref":"#/components/schemas/TransferAddr"
+              "transfers": {
+                "description": "Transfers performed by the Deploy.",
+                "items": {
+                  "$ref": "#/components/schemas/TransferAddr"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "deploy_hash",
               "from",
               "gas",
               "source",
               "transfers"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "DictionaryIdentifier":{
-            "anyOf":[
+          "DictionaryIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via an Account's named keys.",
-                "properties":{
-                  "AccountNamedKey":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via an Account's named keys.",
+                "properties": {
+                  "AccountNamedKey": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "dictionary_name":{
-                        "description":"The named key under which the dictionary seed URef is stored.",
-                        "type":"string"
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
                       },
-                      "key":{
-                        "description":"The account key as a formatted string whose named keys contains dictionary_name.",
-                        "type":"string"
+                      "key": {
+                        "description": "The account key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "dictionary_name",
                       "key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "AccountNamedKey"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via a Contract's named keys.",
-                "properties":{
-                  "ContractNamedKey":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via a Contract's named keys.",
+                "properties": {
+                  "ContractNamedKey": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "dictionary_name":{
-                        "description":"The named key under which the dictionary seed URef is stored.",
-                        "type":"string"
+                      "dictionary_name": {
+                        "description": "The named key under which the dictionary seed URef is stored.",
+                        "type": "string"
                       },
-                      "key":{
-                        "description":"The contract key as a formatted string whose named keys contains dictionary_name.",
-                        "type":"string"
+                      "key": {
+                        "description": "The contract key as a formatted string whose named keys contains dictionary_name.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "dictionary_name",
                       "key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractNamedKey"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via its seed URef.",
-                "properties":{
-                  "URef":{
-                    "properties":{
-                      "dictionary_item_key":{
-                        "description":"The dictionary item key formatted as a string.",
-                        "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via its seed URef.",
+                "properties": {
+                  "URef": {
+                    "properties": {
+                      "dictionary_item_key": {
+                        "description": "The dictionary item key formatted as a string.",
+                        "type": "string"
                       },
-                      "seed_uref":{
-                        "description":"The dictionary's seed URef.",
-                        "type":"string"
+                      "seed_uref": {
+                        "description": "The dictionary's seed URef.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "dictionary_item_key",
                       "seed_uref"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "URef"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Lookup a dictionary item via its unique key.",
-                "properties":{
-                  "Dictionary":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "Lookup a dictionary item via its unique key.",
+                "properties": {
+                  "Dictionary": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "Dictionary"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Options for dictionary item lookups."
+            "description": "Options for dictionary item lookups."
           },
-          "Digest":{
-            "description":"Hex-encoded hash digest.",
-            "type":"string"
+          "Digest": {
+            "description": "Hex-encoded hash digest.",
+            "type": "string"
           },
-          "DisabledVersion":{
-            "properties":{
-              "contract_version":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+          "DisabledVersion": {
+            "properties": {
+              "contract_version": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "protocol_version_major":{
-                "format":"uint32",
-                "minimum":0.0,
-                "type":"integer"
+              "protocol_version_major": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
               }
             },
-            "required":[
+            "required": [
               "contract_version",
               "protocol_version_major"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EntryPoint":{
-            "description":"Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
-            "properties":{
-              "access":{
-                "$ref":"#/components/schemas/EntryPointAccess"
+          "EntryPoint": {
+            "description": "Type signature of a method. Order of arguments matter since can be referenced by index as well as name.",
+            "properties": {
+              "access": {
+                "$ref": "#/components/schemas/EntryPointAccess"
               },
-              "args":{
-                "items":{
-                  "$ref":"#/components/schemas/Parameter"
+              "args": {
+                "items": {
+                  "$ref": "#/components/schemas/Parameter"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "entry_point_type":{
-                "$ref":"#/components/schemas/EntryPointType"
+              "entry_point_type": {
+                "$ref": "#/components/schemas/EntryPointType"
               },
-              "name":{
-                "type":"string"
+              "name": {
+                "type": "string"
               },
-              "ret":{
-                "$ref":"#/components/schemas/CLType"
+              "ret": {
+                "$ref": "#/components/schemas/CLType"
               }
             },
-            "required":[
+            "required": [
               "access",
               "args",
               "entry_point_type",
               "name",
               "ret"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EntryPointAccess":{
-            "anyOf":[
+          "EntryPointAccess": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Public"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
-                "properties":{
-                  "Groups":{
-                    "items":{
-                      "$ref":"#/components/schemas/Group"
+                "additionalProperties": false,
+                "description": "Only users from the listed groups may call this method. Note: if the list is empty then this method is not callable from outside the contract.",
+                "properties": {
+                  "Groups": {
+                    "items": {
+                      "$ref": "#/components/schemas/Group"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Groups"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Enum describing the possible access control options for a contract entry point (method)."
+            "description": "Enum describing the possible access control options for a contract entry point (method)."
           },
-          "EntryPointType":{
-            "description":"Context of method execution",
-            "enum":[
+          "EntryPointType": {
+            "description": "Context of method execution",
+            "enum": [
               "Session",
               "Contract"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "EraId":{
-            "description":"Era ID newtype.",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "EraId": {
+            "description": "Era ID newtype.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "EraInfo":{
-            "additionalProperties":false,
-            "description":"Auction metadata.  Intended to be recorded at each era.",
-            "properties":{
-              "seigniorage_allocations":{
-                "items":{
-                  "$ref":"#/components/schemas/SeigniorageAllocation"
+          "EraInfo": {
+            "additionalProperties": false,
+            "description": "Auction metadata.  Intended to be recorded at each era.",
+            "properties": {
+              "seigniorage_allocations": {
+                "items": {
+                  "$ref": "#/components/schemas/SeigniorageAllocation"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "seigniorage_allocations"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "EraSummary":{
-            "additionalProperties":false,
-            "description":"The summary of an era",
-            "properties":{
-              "block_hash":{
-                "allOf":[
+          "EraSummary": {
+            "additionalProperties": false,
+            "description": "The summary of an era",
+            "properties": {
+              "block_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The block hash"
+                "description": "The block hash"
               },
-              "era_id":{
-                "allOf":[
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The era id"
+                "description": "The era id"
               },
-              "merkle_proof":{
-                "description":"The merkle proof",
-                "type":"string"
+              "merkle_proof": {
+                "description": "The merkle proof",
+                "type": "string"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Hex-encoded hash of the state root"
+                "description": "Hex-encoded hash of the state root"
               },
-              "stored_value":{
-                "allOf":[
+              "stored_value": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/StoredValue"
+                    "$ref": "#/components/schemas/StoredValue"
                   }
                 ],
-                "description":"The StoredValue containing era information"
+                "description": "The StoredValue containing era information"
               }
             },
-            "required":[
+            "required": [
               "block_hash",
               "era_id",
               "merkle_proof",
               "state_root_hash",
               "stored_value"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ExecutableDeployItem":{
-            "anyOf":[
+          "ExecutableDeployItem": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "properties":{
-                  "ModuleBytes":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "ModuleBytes": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "module_bytes":{
-                        "description":"Hex-encoded raw Wasm bytes.",
-                        "type":"string"
+                      "module_bytes": {
+                        "description": "Hex-encoded raw Wasm bytes.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "module_bytes"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "ModuleBytes"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredContractByHash":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredContractByHash": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "hash":{
-                        "description":"Hex-encoded hash.",
-                        "type":"string"
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "hash"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredContractByHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredContractByName":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredContractByName": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "name":{
-                        "type":"string"
+                      "name": {
+                        "type": "string"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "name"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredContractByName"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredVersionedContractByHash":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredVersionedContractByHash": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "hash":{
-                        "description":"Hex-encoded hash.",
-                        "type":"string"
+                      "hash": {
+                        "description": "Hex-encoded hash.",
+                        "type": "string"
                       },
-                      "version":{
-                        "format":"uint32",
-                        "minimum":0.0,
-                        "type":[
+                      "version": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
                           "integer",
                           "null"
                         ]
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "hash"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredVersionedContractByHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "StoredVersionedContractByName":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "StoredVersionedContractByName": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       },
-                      "entry_point":{
-                        "type":"string"
+                      "entry_point": {
+                        "type": "string"
                       },
-                      "name":{
-                        "type":"string"
+                      "name": {
+                        "type": "string"
                       },
-                      "version":{
-                        "format":"uint32",
-                        "minimum":0.0,
-                        "type":[
+                      "version": {
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": [
                           "integer",
                           "null"
                         ]
                       }
                     },
-                    "required":[
+                    "required": [
                       "args",
                       "entry_point",
                       "name"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "StoredVersionedContractByName"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "properties":{
-                  "Transfer":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "args":{
-                        "$ref":"#/components/schemas/RuntimeArgs"
+                "additionalProperties": false,
+                "properties": {
+                  "Transfer": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "args": {
+                        "$ref": "#/components/schemas/RuntimeArgs"
                       }
                     },
-                    "required":[
+                    "required": [
                       "args"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Transfer"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ]
           },
-          "ExecutionEffect":{
-            "additionalProperties":false,
-            "description":"The effect of executing a single deploy.",
-            "properties":{
-              "operations":{
-                "description":"The resulting operations.",
-                "items":{
-                  "$ref":"#/components/schemas/Operation"
+          "ExecutionEffect": {
+            "additionalProperties": false,
+            "description": "The effect of executing a single deploy.",
+            "properties": {
+              "operations": {
+                "description": "The resulting operations.",
+                "items": {
+                  "$ref": "#/components/schemas/Operation"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "transforms":{
-                "description":"The resulting transformations.",
-                "items":{
-                  "$ref":"#/components/schemas/TransformEntry"
+              "transforms": {
+                "description": "The resulting transformations.",
+                "items": {
+                  "$ref": "#/components/schemas/TransformEntry"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "operations",
               "transforms"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ExecutionResult":{
-            "anyOf":[
+          "ExecutionResult": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"The result of a failed execution.",
-                "properties":{
-                  "Failure":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "cost":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "The result of a failed execution.",
+                "properties": {
+                  "Failure": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "cost": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"The cost of executing the deploy."
+                        "description": "The cost of executing the deploy."
                       },
-                      "effect":{
-                        "allOf":[
+                      "effect": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/ExecutionEffect"
+                            "$ref": "#/components/schemas/ExecutionEffect"
                           }
                         ],
-                        "description":"The effect of executing the deploy."
+                        "description": "The effect of executing the deploy."
                       },
-                      "error_message":{
-                        "description":"The error message associated with executing the deploy.",
-                        "type":"string"
+                      "error_message": {
+                        "description": "The error message associated with executing the deploy.",
+                        "type": "string"
                       },
-                      "transfers":{
-                        "description":"A record of Transfers performed while executing the deploy.",
-                        "items":{
-                          "$ref":"#/components/schemas/TransferAddr"
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
                         },
-                        "type":"array"
+                        "type": "array"
                       }
                     },
-                    "required":[
+                    "required": [
                       "cost",
                       "effect",
                       "error_message",
                       "transfers"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Failure"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"The result of a successful execution.",
-                "properties":{
-                  "Success":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "cost":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "The result of a successful execution.",
+                "properties": {
+                  "Success": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "cost": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"The cost of executing the deploy."
+                        "description": "The cost of executing the deploy."
                       },
-                      "effect":{
-                        "allOf":[
+                      "effect": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/ExecutionEffect"
+                            "$ref": "#/components/schemas/ExecutionEffect"
                           }
                         ],
-                        "description":"The effect of executing the deploy."
+                        "description": "The effect of executing the deploy."
                       },
-                      "transfers":{
-                        "description":"A record of Transfers performed while executing the deploy.",
-                        "items":{
-                          "$ref":"#/components/schemas/TransferAddr"
+                      "transfers": {
+                        "description": "A record of Transfers performed while executing the deploy.",
+                        "items": {
+                          "$ref": "#/components/schemas/TransferAddr"
                         },
-                        "type":"array"
+                        "type": "array"
                       }
                     },
-                    "required":[
+                    "required": [
                       "cost",
                       "effect",
                       "transfers"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Success"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"The result of executing a single deploy."
+            "description": "The result of executing a single deploy."
           },
-          "GlobalStateIdentifier":{
-            "anyOf":[
+          "GlobalStateIdentifier": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Query using a block hash.",
-                "properties":{
-                  "BlockHash":{
-                    "$ref":"#/components/schemas/BlockHash"
+                "additionalProperties": false,
+                "description": "Query using a block hash.",
+                "properties": {
+                  "BlockHash": {
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 },
-                "required":[
+                "required": [
                   "BlockHash"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Query using the state root hash.",
-                "properties":{
-                  "StateRootHash":{
-                    "$ref":"#/components/schemas/Digest"
+                "additionalProperties": false,
+                "description": "Query using the state root hash.",
+                "properties": {
+                  "StateRootHash": {
+                    "$ref": "#/components/schemas/Digest"
                   }
                 },
-                "required":[
+                "required": [
                   "StateRootHash"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Identifier for possible ways to query Global State"
+            "description": "Identifier for possible ways to query Global State"
           },
-          "Group":{
-            "description":"A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
-            "type":"string"
+          "Group": {
+            "description": "A (labelled) \"user group\". Each method of a versioned contract may be associated with one or more user groups which are allowed to call it.",
+            "type": "string"
           },
-          "Groups":{
-            "properties":{
-              "group":{
-                "type":"string"
+          "Groups": {
+            "properties": {
+              "group": {
+                "type": "string"
               },
-              "keys":{
-                "items":{
-                  "$ref":"#/components/schemas/URef"
+              "keys": {
+                "items": {
+                  "$ref": "#/components/schemas/URef"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "group",
               "keys"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBid":{
-            "additionalProperties":false,
-            "description":"An entry in a founding validator map representing a bid.",
-            "properties":{
-              "bonding_purse":{
-                "allOf":[
+          "JsonBid": {
+            "additionalProperties": false,
+            "description": "An entry in a founding validator map representing a bid.",
+            "properties": {
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"The purse that was used for bonding."
+                "description": "The purse that was used for bonding."
               },
-              "delegation_rate":{
-                "description":"The delegation rate.",
-                "format":"uint8",
-                "minimum":0.0,
-                "type":"integer"
+              "delegation_rate": {
+                "description": "The delegation rate.",
+                "format": "uint8",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "delegators":{
-                "description":"The delegators.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonDelegator"
+              "delegators": {
+                "description": "The delegators.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonDelegator"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "inactive":{
-                "description":"Is this an inactive validator.",
-                "type":"boolean"
+              "inactive": {
+                "description": "Is this an inactive validator.",
+                "type": "boolean"
               },
-              "staked_amount":{
-                "allOf":[
+              "staked_amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"The amount of tokens staked by a validator (not including delegators)."
+                "description": "The amount of tokens staked by a validator (not including delegators)."
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegation_rate",
               "delegators",
               "inactive",
               "staked_amount"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBids":{
-            "additionalProperties":false,
-            "description":"A Json representation of a single bid.",
-            "properties":{
-              "bid":{
-                "$ref":"#/components/schemas/JsonBid"
+          "JsonBids": {
+            "additionalProperties": false,
+            "description": "A Json representation of a single bid.",
+            "properties": {
+              "bid": {
+                "$ref": "#/components/schemas/JsonBid"
               },
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "bid",
               "public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlock":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of `Block`.",
-            "properties":{
-              "body":{
-                "allOf":[
+          "JsonBlock": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of `Block`.",
+            "properties": {
+              "body": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/JsonBlockBody"
+                    "$ref": "#/components/schemas/JsonBlockBody"
                   }
                 ],
-                "description":"JSON-friendly block body."
+                "description": "JSON-friendly block body."
               },
-              "hash":{
-                "allOf":[
+              "hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"`BlockHash`"
+                "description": "`BlockHash`"
               },
-              "header":{
-                "allOf":[
+              "header": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/JsonBlockHeader"
+                    "$ref": "#/components/schemas/JsonBlockHeader"
                   }
                 ],
-                "description":"JSON-friendly block header."
+                "description": "JSON-friendly block header."
               },
-              "proofs":{
-                "description":"JSON-friendly list of proofs for this block.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonProof"
+              "proofs": {
+                "description": "JSON-friendly list of proofs for this block.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonProof"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "body",
               "hash",
               "header",
               "proofs"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlockBody":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of `Body`",
-            "properties":{
-              "deploy_hashes":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+          "JsonBlockBody": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of `Body`",
+            "properties": {
+              "deploy_hashes": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "proposer":{
-                "$ref":"#/components/schemas/PublicKey"
+              "proposer": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "transfer_hashes":{
-                "items":{
-                  "$ref":"#/components/schemas/DeployHash"
+              "transfer_hashes": {
+                "items": {
+                  "$ref": "#/components/schemas/DeployHash"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "deploy_hashes",
               "proposer",
               "transfer_hashes"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonBlockHeader":{
-            "additionalProperties":false,
-            "description":"JSON representation of a block header.",
-            "properties":{
-              "accumulated_seed":{
-                "allOf":[
+          "JsonBlockHeader": {
+            "additionalProperties": false,
+            "description": "JSON representation of a block header.",
+            "properties": {
+              "accumulated_seed": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"Accumulated seed."
+                "description": "Accumulated seed."
               },
-              "body_hash":{
-                "allOf":[
+              "body_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"The body hash."
+                "description": "The body hash."
               },
-              "era_end":{
-                "anyOf":[
+              "era_end": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/JsonEraEnd"
+                    "$ref": "#/components/schemas/JsonEraEnd"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"The era end."
+                "description": "The era end."
               },
-              "era_id":{
-                "allOf":[
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The block era id."
+                "description": "The block era id."
               },
-              "height":{
-                "description":"The block height.",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "height": {
+                "description": "The block height.",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "parent_hash":{
-                "allOf":[
+              "parent_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The parent hash."
+                "description": "The parent hash."
               },
-              "protocol_version":{
-                "allOf":[
+              "protocol_version": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ProtocolVersion"
+                    "$ref": "#/components/schemas/ProtocolVersion"
                   }
                 ],
-                "description":"The protocol version."
+                "description": "The protocol version."
               },
-              "random_bit":{
-                "description":"Randomness bit.",
-                "type":"boolean"
+              "random_bit": {
+                "description": "Randomness bit.",
+                "type": "boolean"
               },
-              "state_root_hash":{
-                "allOf":[
+              "state_root_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Digest"
+                    "$ref": "#/components/schemas/Digest"
                   }
                 ],
-                "description":"The state root hash."
+                "description": "The state root hash."
               },
-              "timestamp":{
-                "allOf":[
+              "timestamp": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Timestamp"
+                    "$ref": "#/components/schemas/Timestamp"
                   }
                 ],
-                "description":"The block timestamp."
+                "description": "The block timestamp."
               }
             },
-            "required":[
+            "required": [
               "accumulated_seed",
               "body_hash",
               "era_id",
@@ -1583,242 +1583,242 @@
               "state_root_hash",
               "timestamp"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonDelegator":{
-            "additionalProperties":false,
-            "description":"A delegator associated with the given validator.",
-            "properties":{
-              "bonding_purse":{
-                "$ref":"#/components/schemas/URef"
+          "JsonDelegator": {
+            "additionalProperties": false,
+            "description": "A delegator associated with the given validator.",
+            "properties": {
+              "bonding_purse": {
+                "$ref": "#/components/schemas/URef"
               },
-              "delegatee":{
-                "$ref":"#/components/schemas/PublicKey"
+              "delegatee": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "staked_amount":{
-                "$ref":"#/components/schemas/U512"
+              "staked_amount": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "bonding_purse",
               "delegatee",
               "public_key",
               "staked_amount"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraChange":{
-            "additionalProperties":false,
-            "description":"A single change to a validator's status between two eras.",
-            "properties":{
-              "era_id":{
-                "allOf":[
+          "JsonEraChange": {
+            "additionalProperties": false,
+            "description": "A single change to a validator's status in the given era.",
+            "properties": {
+              "era_id": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"The era in which the change occurred."
+                "description": "The era in which the change occurred."
               },
-              "validator_change":{
-                "allOf":[
+              "validator_change": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ValidatorChange"
+                    "$ref": "#/components/schemas/ValidatorChange"
                   }
                 ],
-                "description":"The change in validator status."
+                "description": "The change in validator status."
               }
             },
-            "required":[
+            "required": [
               "era_id",
               "validator_change"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraEnd":{
-            "additionalProperties":false,
-            "properties":{
-              "era_report":{
-                "$ref":"#/components/schemas/JsonEraReport"
+          "JsonEraEnd": {
+            "additionalProperties": false,
+            "properties": {
+              "era_report": {
+                "$ref": "#/components/schemas/JsonEraReport"
               },
-              "next_era_validator_weights":{
-                "items":{
-                  "$ref":"#/components/schemas/ValidatorWeight"
+              "next_era_validator_weights": {
+                "items": {
+                  "$ref": "#/components/schemas/ValidatorWeight"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "era_report",
               "next_era_validator_weights"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraReport":{
-            "additionalProperties":false,
-            "description":"Equivocation and reward information to be included in the terminal block.",
-            "properties":{
-              "equivocators":{
-                "items":{
-                  "$ref":"#/components/schemas/PublicKey"
+          "JsonEraReport": {
+            "additionalProperties": false,
+            "description": "Equivocation and reward information to be included in the terminal block.",
+            "properties": {
+              "equivocators": {
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "inactive_validators":{
-                "items":{
-                  "$ref":"#/components/schemas/PublicKey"
+              "inactive_validators": {
+                "items": {
+                  "$ref": "#/components/schemas/PublicKey"
                 },
-                "type":"array"
+                "type": "array"
               },
-              "rewards":{
-                "items":{
-                  "$ref":"#/components/schemas/Reward"
+              "rewards": {
+                "items": {
+                  "$ref": "#/components/schemas/Reward"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "equivocators",
               "inactive_validators",
               "rewards"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonEraValidators":{
-            "additionalProperties":false,
-            "description":"The validators for the given era.",
-            "properties":{
-              "era_id":{
-                "$ref":"#/components/schemas/EraId"
+          "JsonEraValidators": {
+            "additionalProperties": false,
+            "description": "The validators for the given era.",
+            "properties": {
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
               },
-              "validator_weights":{
-                "items":{
-                  "$ref":"#/components/schemas/JsonValidatorWeights"
+              "validator_weights": {
+                "items": {
+                  "$ref": "#/components/schemas/JsonValidatorWeights"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "era_id",
               "validator_weights"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonExecutionResult":{
-            "additionalProperties":false,
-            "description":"The execution result of a single deploy.",
-            "properties":{
-              "block_hash":{
-                "allOf":[
+          "JsonExecutionResult": {
+            "additionalProperties": false,
+            "description": "The execution result of a single deploy.",
+            "properties": {
+              "block_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/BlockHash"
+                    "$ref": "#/components/schemas/BlockHash"
                   }
                 ],
-                "description":"The block hash."
+                "description": "The block hash."
               },
-              "result":{
-                "allOf":[
+              "result": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/ExecutionResult"
+                    "$ref": "#/components/schemas/ExecutionResult"
                   }
                 ],
-                "description":"Execution result."
+                "description": "Execution result."
               }
             },
-            "required":[
+            "required": [
               "block_hash",
               "result"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonProof":{
-            "additionalProperties":false,
-            "description":"A JSON-friendly representation of a proof, i.e. a block's finality signature.",
-            "properties":{
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+          "JsonProof": {
+            "additionalProperties": false,
+            "description": "A JSON-friendly representation of a proof, i.e. a block's finality signature.",
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "signature":{
-                "$ref":"#/components/schemas/Signature"
+              "signature": {
+                "$ref": "#/components/schemas/Signature"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "signature"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonValidatorInfo":{
-            "additionalProperties":false,
-            "description":"The changes in a validator's status between any two eras.",
-            "properties":{
-              "public_key":{
-                "allOf":[
+          "JsonValidatorChanges": {
+            "additionalProperties": false,
+            "description": "The changes in a validator's status.",
+            "properties": {
+              "public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"The public key of a given validator."
+                "description": "The public key of the validator."
               },
-              "status_changes":{
-                "description":"The set of changes to the validator's status.",
-                "items":{
-                  "$ref":"#/components/schemas/JsonEraChange"
+              "status_changes": {
+                "description": "The set of changes to the validator's status.",
+                "items": {
+                  "$ref": "#/components/schemas/JsonEraChange"
                 },
-                "type":"array"
+                "type": "array"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "status_changes"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "JsonValidatorWeights":{
-            "additionalProperties":false,
-            "description":"A validator's weight.",
-            "properties":{
-              "public_key":{
-                "$ref":"#/components/schemas/PublicKey"
+          "JsonValidatorWeights": {
+            "additionalProperties": false,
+            "description": "A validator's weight.",
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "weight":{
-                "$ref":"#/components/schemas/U512"
+              "weight": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "public_key",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "MinimalBlockInfo":{
-            "additionalProperties":false,
-            "description":"Minimal info of a `Block`.",
-            "properties":{
-              "creator":{
-                "$ref":"#/components/schemas/PublicKey"
+          "MinimalBlockInfo": {
+            "additionalProperties": false,
+            "description": "Minimal info of a `Block`.",
+            "properties": {
+              "creator": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "era_id":{
-                "$ref":"#/components/schemas/EraId"
+              "era_id": {
+                "$ref": "#/components/schemas/EraId"
               },
-              "hash":{
-                "$ref":"#/components/schemas/BlockHash"
+              "hash": {
+                "$ref": "#/components/schemas/BlockHash"
               },
-              "height":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+              "height": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "state_root_hash":{
-                "$ref":"#/components/schemas/Digest"
+              "state_root_hash": {
+                "$ref": "#/components/schemas/Digest"
               },
-              "timestamp":{
-                "$ref":"#/components/schemas/Timestamp"
+              "timestamp": {
+                "$ref": "#/components/schemas/Timestamp"
               }
             },
-            "required":[
+            "required": [
               "creator",
               "era_id",
               "hash",
@@ -1826,476 +1826,476 @@
               "state_root_hash",
               "timestamp"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "NamedArg":{
-            "description":"Named arguments to a contract",
-            "items":[
+          "NamedArg": {
+            "description": "Named arguments to a contract",
+            "items": [
               {
-                "type":"string"
+                "type": "string"
               },
               {
-                "$ref":"#/components/schemas/CLValue"
+                "$ref": "#/components/schemas/CLValue"
               }
             ],
-            "maxItems":2,
-            "minItems":2,
-            "type":"array"
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
           },
-          "NamedKey":{
-            "additionalProperties":false,
-            "description":"A named key.",
-            "properties":{
-              "key":{
-                "description":"The value of the entry: a casper `Key` type.",
-                "type":"string"
+          "NamedKey": {
+            "additionalProperties": false,
+            "description": "A named key.",
+            "properties": {
+              "key": {
+                "description": "The value of the entry: a casper `Key` type.",
+                "type": "string"
               },
-              "name":{
-                "description":"The name of the entry.",
-                "type":"string"
+              "name": {
+                "description": "The name of the entry.",
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "key",
               "name"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "NextUpgrade":{
-            "description":"Information about the next protocol upgrade.",
-            "properties":{
-              "activation_point":{
-                "$ref":"#/components/schemas/ActivationPoint"
+          "NextUpgrade": {
+            "description": "Information about the next protocol upgrade.",
+            "properties": {
+              "activation_point": {
+                "$ref": "#/components/schemas/ActivationPoint"
               },
-              "protocol_version":{
-                "type":"string"
+              "protocol_version": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "activation_point",
               "protocol_version"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "OpKind":{
-            "description":"The type of operation performed while executing a deploy.",
-            "enum":[
+          "OpKind": {
+            "description": "The type of operation performed while executing a deploy.",
+            "enum": [
               "Read",
               "Write",
               "Add",
               "NoOp"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "Operation":{
-            "additionalProperties":false,
-            "description":"An operation performed while executing a deploy.",
-            "properties":{
-              "key":{
-                "description":"The formatted string of the `Key`.",
-                "type":"string"
+          "Operation": {
+            "additionalProperties": false,
+            "description": "An operation performed while executing a deploy.",
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
               },
-              "kind":{
-                "allOf":[
+              "kind": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/OpKind"
+                    "$ref": "#/components/schemas/OpKind"
                   }
                 ],
-                "description":"The type of operation."
+                "description": "The type of operation."
               }
             },
-            "required":[
+            "required": [
               "key",
               "kind"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "Parameter":{
-            "description":"Parameter to a method",
-            "properties":{
-              "cl_type":{
-                "$ref":"#/components/schemas/CLType"
+          "Parameter": {
+            "description": "Parameter to a method",
+            "properties": {
+              "cl_type": {
+                "$ref": "#/components/schemas/CLType"
               },
-              "name":{
-                "type":"string"
+              "name": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "cl_type",
               "name"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "PeerEntry":{
-            "additionalProperties":false,
-            "properties":{
-              "address":{
-                "type":"string"
+          "PeerEntry": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "type": "string"
               },
-              "node_id":{
-                "type":"string"
+              "node_id": {
+                "type": "string"
               }
             },
-            "required":[
+            "required": [
               "address",
               "node_id"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "PeersMap":{
-            "description":"Map of peer IDs to network addresses.",
-            "items":{
-              "$ref":"#/components/schemas/PeerEntry"
+          "PeersMap": {
+            "description": "Map of peer IDs to network addresses.",
+            "items": {
+              "$ref": "#/components/schemas/PeerEntry"
             },
-            "type":"array"
+            "type": "array"
           },
-          "ProtocolVersion":{
-            "description":"Casper Platform protocol version",
-            "type":"string"
+          "ProtocolVersion": {
+            "description": "Casper Platform protocol version",
+            "type": "string"
           },
-          "PublicKey":{
-            "description":"Hex-encoded cryptographic public key, including the algorithm tag prefix.",
-            "type":"string"
+          "PublicKey": {
+            "description": "Hex-encoded cryptographic public key, including the algorithm tag prefix.",
+            "type": "string"
           },
-          "Reward":{
-            "additionalProperties":false,
-            "properties":{
-              "amount":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+          "Reward": {
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "validator":{
-                "$ref":"#/components/schemas/PublicKey"
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
               }
             },
-            "required":[
+            "required": [
               "amount",
               "validator"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "RuntimeArgs":{
-            "description":"Represents a collection of arguments passed to a smart contract.",
-            "items":{
-              "$ref":"#/components/schemas/NamedArg"
+          "RuntimeArgs": {
+            "description": "Represents a collection of arguments passed to a smart contract.",
+            "items": {
+              "$ref": "#/components/schemas/NamedArg"
             },
-            "type":"array"
+            "type": "array"
           },
-          "SeigniorageAllocation":{
-            "anyOf":[
+          "SeigniorageAllocation": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"Info about a seigniorage allocation for a validator",
-                "properties":{
-                  "Validator":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "amount":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "Info about a seigniorage allocation for a validator",
+                "properties": {
+                  "Validator": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"Allocated amount"
+                        "description": "Allocated amount"
                       },
-                      "validator_public_key":{
-                        "allOf":[
+                      "validator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Validator's public key"
+                        "description": "Validator's public key"
                       }
                     },
-                    "required":[
+                    "required": [
                       "amount",
                       "validator_public_key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Validator"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Info about a seigniorage allocation for a delegator",
-                "properties":{
-                  "Delegator":{
-                    "additionalProperties":false,
-                    "properties":{
-                      "amount":{
-                        "allOf":[
+                "additionalProperties": false,
+                "description": "Info about a seigniorage allocation for a delegator",
+                "properties": {
+                  "Delegator": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/U512"
+                            "$ref": "#/components/schemas/U512"
                           }
                         ],
-                        "description":"Allocated amount"
+                        "description": "Allocated amount"
                       },
-                      "delegator_public_key":{
-                        "allOf":[
+                      "delegator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Delegator's public key"
+                        "description": "Delegator's public key"
                       },
-                      "validator_public_key":{
-                        "allOf":[
+                      "validator_public_key": {
+                        "allOf": [
                           {
-                            "$ref":"#/components/schemas/PublicKey"
+                            "$ref": "#/components/schemas/PublicKey"
                           }
                         ],
-                        "description":"Validator's public key"
+                        "description": "Validator's public key"
                       }
                     },
-                    "required":[
+                    "required": [
                       "amount",
                       "delegator_public_key",
                       "validator_public_key"
                     ],
-                    "type":"object"
+                    "type": "object"
                   }
                 },
-                "required":[
+                "required": [
                   "Delegator"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Information about a seigniorage allocation"
+            "description": "Information about a seigniorage allocation"
           },
-          "Signature":{
-            "description":"Hex-encoded cryptographic signature, including the algorithm tag prefix.",
-            "type":"string"
+          "Signature": {
+            "description": "Hex-encoded cryptographic signature, including the algorithm tag prefix.",
+            "type": "string"
           },
-          "StoredValue":{
-            "anyOf":[
+          "StoredValue": {
+            "anyOf": [
               {
-                "additionalProperties":false,
-                "description":"A CasperLabs value.",
-                "properties":{
-                  "CLValue":{
-                    "$ref":"#/components/schemas/CLValue"
+                "additionalProperties": false,
+                "description": "A CasperLabs value.",
+                "properties": {
+                  "CLValue": {
+                    "$ref": "#/components/schemas/CLValue"
                   }
                 },
-                "required":[
+                "required": [
                   "CLValue"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"An account.",
-                "properties":{
-                  "Account":{
-                    "$ref":"#/components/schemas/Account"
+                "additionalProperties": false,
+                "description": "An account.",
+                "properties": {
+                  "Account": {
+                    "$ref": "#/components/schemas/Account"
                   }
                 },
-                "required":[
+                "required": [
                   "Account"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A contract's Wasm",
-                "properties":{
-                  "ContractWasm":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "A contract's Wasm",
+                "properties": {
+                  "ContractWasm": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractWasm"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Methods and type signatures supported by a contract.",
-                "properties":{
-                  "Contract":{
-                    "$ref":"#/components/schemas/Contract"
+                "additionalProperties": false,
+                "description": "Methods and type signatures supported by a contract.",
+                "properties": {
+                  "Contract": {
+                    "$ref": "#/components/schemas/Contract"
                   }
                 },
-                "required":[
+                "required": [
                   "Contract"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A contract definition, metadata, and security container.",
-                "properties":{
-                  "ContractPackage":{
-                    "$ref":"#/components/schemas/ContractPackage"
+                "additionalProperties": false,
+                "description": "A contract definition, metadata, and security container.",
+                "properties": {
+                  "ContractPackage": {
+                    "$ref": "#/components/schemas/ContractPackage"
                   }
                 },
-                "required":[
+                "required": [
                   "ContractPackage"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A record of a transfer",
-                "properties":{
-                  "Transfer":{
-                    "$ref":"#/components/schemas/Transfer"
+                "additionalProperties": false,
+                "description": "A record of a transfer",
+                "properties": {
+                  "Transfer": {
+                    "$ref": "#/components/schemas/Transfer"
                   }
                 },
-                "required":[
+                "required": [
                   "Transfer"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A record of a deploy",
-                "properties":{
-                  "DeployInfo":{
-                    "$ref":"#/components/schemas/DeployInfo"
+                "additionalProperties": false,
+                "description": "A record of a deploy",
+                "properties": {
+                  "DeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "DeployInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Auction metadata",
-                "properties":{
-                  "EraInfo":{
-                    "$ref":"#/components/schemas/EraInfo"
+                "additionalProperties": false,
+                "description": "Auction metadata",
+                "properties": {
+                  "EraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "EraInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A bid",
-                "properties":{
-                  "Bid":{
-                    "$ref":"#/components/schemas/Bid"
+                "additionalProperties": false,
+                "description": "A bid",
+                "properties": {
+                  "Bid": {
+                    "$ref": "#/components/schemas/Bid"
                   }
                 },
-                "required":[
+                "required": [
                   "Bid"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A withdraw",
-                "properties":{
-                  "Withdraw":{
-                    "items":{
-                      "$ref":"#/components/schemas/UnbondingPurse"
+                "additionalProperties": false,
+                "description": "A withdraw",
+                "properties": {
+                  "Withdraw": {
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "Withdraw"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
+            "description": "Representation of a value stored in global state.\n\n`Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representations (see their docs for further info)."
           },
-          "TimeDiff":{
-            "description":"Human-readable duration.",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "TimeDiff": {
+            "description": "Human-readable duration.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "Timestamp":{
-            "description":"Timestamp formatted as per RFC 3339",
-            "format":"uint64",
-            "minimum":0.0,
-            "type":"integer"
+          "Timestamp": {
+            "description": "Timestamp formatted as per RFC 3339",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           },
-          "Transfer":{
-            "additionalProperties":false,
-            "description":"Represents a transfer from one purse to another",
-            "properties":{
-              "amount":{
-                "allOf":[
+          "Transfer": {
+            "additionalProperties": false,
+            "description": "Represents a transfer from one purse to another",
+            "properties": {
+              "amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Transfer amount"
+                "description": "Transfer amount"
               },
-              "deploy_hash":{
-                "allOf":[
+              "deploy_hash": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/DeployHash"
+                    "$ref": "#/components/schemas/DeployHash"
                   }
                 ],
-                "description":"Deploy that created the transfer"
+                "description": "Deploy that created the transfer"
               },
-              "from":{
-                "allOf":[
+              "from": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 ],
-                "description":"Account from which transfer was executed"
+                "description": "Account from which transfer was executed"
               },
-              "gas":{
-                "allOf":[
+              "gas": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Gas"
+                "description": "Gas"
               },
-              "id":{
-                "description":"User-defined id",
-                "format":"uint64",
-                "minimum":0.0,
-                "type":[
+              "id": {
+                "description": "User-defined id",
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": [
                   "integer",
                   "null"
                 ]
               },
-              "source":{
-                "allOf":[
+              "source": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Source purse"
+                "description": "Source purse"
               },
-              "target":{
-                "allOf":[
+              "target": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Target purse"
+                "description": "Target purse"
               },
-              "to":{
-                "anyOf":[
+              "to": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/AccountHash"
+                    "$ref": "#/components/schemas/AccountHash"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"Account to which funds are transferred"
+                "description": "Account to which funds are transferred"
               }
             },
-            "required":[
+            "required": [
               "amount",
               "deploy_hash",
               "from",
@@ -2303,429 +2303,429 @@
               "source",
               "target"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "TransferAddr":{
-            "description":"Hex-encoded transfer address.",
-            "type":"string"
+          "TransferAddr": {
+            "description": "Hex-encoded transfer address.",
+            "type": "string"
           },
-          "Transform":{
-            "anyOf":[
+          "Transform": {
+            "anyOf": [
               {
-                "enum":[
+                "enum": [
                   "Identity",
                   "WriteContractWasm",
                   "WriteContract",
                   "WriteContractPackage"
                 ],
-                "type":"string"
+                "type": "string"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given CLValue to global state.",
-                "properties":{
-                  "WriteCLValue":{
-                    "$ref":"#/components/schemas/CLValue"
+                "additionalProperties": false,
+                "description": "Writes the given CLValue to global state.",
+                "properties": {
+                  "WriteCLValue": {
+                    "$ref": "#/components/schemas/CLValue"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteCLValue"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Account to global state.",
-                "properties":{
-                  "WriteAccount":{
-                    "$ref":"#/components/schemas/AccountHash"
+                "additionalProperties": false,
+                "description": "Writes the given Account to global state.",
+                "properties": {
+                  "WriteAccount": {
+                    "$ref": "#/components/schemas/AccountHash"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteAccount"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given DeployInfo to global state.",
-                "properties":{
-                  "WriteDeployInfo":{
-                    "$ref":"#/components/schemas/DeployInfo"
+                "additionalProperties": false,
+                "description": "Writes the given DeployInfo to global state.",
+                "properties": {
+                  "WriteDeployInfo": {
+                    "$ref": "#/components/schemas/DeployInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteDeployInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given EraInfo to global state.",
-                "properties":{
-                  "WriteEraInfo":{
-                    "$ref":"#/components/schemas/EraInfo"
+                "additionalProperties": false,
+                "description": "Writes the given EraInfo to global state.",
+                "properties": {
+                  "WriteEraInfo": {
+                    "$ref": "#/components/schemas/EraInfo"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteEraInfo"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Transfer to global state.",
-                "properties":{
-                  "WriteTransfer":{
-                    "$ref":"#/components/schemas/Transfer"
+                "additionalProperties": false,
+                "description": "Writes the given Transfer to global state.",
+                "properties": {
+                  "WriteTransfer": {
+                    "$ref": "#/components/schemas/Transfer"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteTransfer"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Bid to global state.",
-                "properties":{
-                  "WriteBid":{
-                    "$ref":"#/components/schemas/Bid"
+                "additionalProperties": false,
+                "description": "Writes the given Bid to global state.",
+                "properties": {
+                  "WriteBid": {
+                    "$ref": "#/components/schemas/Bid"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteBid"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Writes the given Withdraw to global state.",
-                "properties":{
-                  "WriteWithdraw":{
-                    "items":{
-                      "$ref":"#/components/schemas/UnbondingPurse"
+                "additionalProperties": false,
+                "description": "Writes the given Withdraw to global state.",
+                "properties": {
+                  "WriteWithdraw": {
+                    "items": {
+                      "$ref": "#/components/schemas/UnbondingPurse"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "WriteWithdraw"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `i32`.",
-                "properties":{
-                  "AddInt32":{
-                    "format":"int32",
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Adds the given `i32`.",
+                "properties": {
+                  "AddInt32": {
+                    "format": "int32",
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "AddInt32"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `u64`.",
-                "properties":{
-                  "AddUInt64":{
-                    "format":"uint64",
-                    "minimum":0.0,
-                    "type":"integer"
+                "additionalProperties": false,
+                "description": "Adds the given `u64`.",
+                "properties": {
+                  "AddUInt64": {
+                    "format": "uint64",
+                    "minimum": 0.0,
+                    "type": "integer"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt64"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U128`.",
-                "properties":{
-                  "AddUInt128":{
-                    "$ref":"#/components/schemas/U128"
+                "additionalProperties": false,
+                "description": "Adds the given `U128`.",
+                "properties": {
+                  "AddUInt128": {
+                    "$ref": "#/components/schemas/U128"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt128"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U256`.",
-                "properties":{
-                  "AddUInt256":{
-                    "$ref":"#/components/schemas/U256"
+                "additionalProperties": false,
+                "description": "Adds the given `U256`.",
+                "properties": {
+                  "AddUInt256": {
+                    "$ref": "#/components/schemas/U256"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt256"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given `U512`.",
-                "properties":{
-                  "AddUInt512":{
-                    "$ref":"#/components/schemas/U512"
+                "additionalProperties": false,
+                "description": "Adds the given `U512`.",
+                "properties": {
+                  "AddUInt512": {
+                    "$ref": "#/components/schemas/U512"
                   }
                 },
-                "required":[
+                "required": [
                   "AddUInt512"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"Adds the given collection of named keys.",
-                "properties":{
-                  "AddKeys":{
-                    "items":{
-                      "$ref":"#/components/schemas/NamedKey"
+                "additionalProperties": false,
+                "description": "Adds the given collection of named keys.",
+                "properties": {
+                  "AddKeys": {
+                    "items": {
+                      "$ref": "#/components/schemas/NamedKey"
                     },
-                    "type":"array"
+                    "type": "array"
                   }
                 },
-                "required":[
+                "required": [
                   "AddKeys"
                 ],
-                "type":"object"
+                "type": "object"
               },
               {
-                "additionalProperties":false,
-                "description":"A failed transformation, containing an error message.",
-                "properties":{
-                  "Failure":{
-                    "type":"string"
+                "additionalProperties": false,
+                "description": "A failed transformation, containing an error message.",
+                "properties": {
+                  "Failure": {
+                    "type": "string"
                   }
                 },
-                "required":[
+                "required": [
                   "Failure"
                 ],
-                "type":"object"
+                "type": "object"
               }
             ],
-            "description":"The actual transformation performed while executing a deploy."
+            "description": "The actual transformation performed while executing a deploy."
           },
-          "TransformEntry":{
-            "additionalProperties":false,
-            "description":"A transformation performed while executing a deploy.",
-            "properties":{
-              "key":{
-                "description":"The formatted string of the `Key`.",
-                "type":"string"
+          "TransformEntry": {
+            "additionalProperties": false,
+            "description": "A transformation performed while executing a deploy.",
+            "properties": {
+              "key": {
+                "description": "The formatted string of the `Key`.",
+                "type": "string"
               },
-              "transform":{
-                "allOf":[
+              "transform": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/Transform"
+                    "$ref": "#/components/schemas/Transform"
                   }
                 ],
-                "description":"The transformation."
+                "description": "The transformation."
               }
             },
-            "required":[
+            "required": [
               "key",
               "transform"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "U128":{
-            "description":"Decimal representation of a 128-bit integer.",
-            "type":"string"
+          "U128": {
+            "description": "Decimal representation of a 128-bit integer.",
+            "type": "string"
           },
-          "U256":{
-            "description":"Decimal representation of a 256-bit integer.",
-            "type":"string"
+          "U256": {
+            "description": "Decimal representation of a 256-bit integer.",
+            "type": "string"
           },
-          "U512":{
-            "description":"Decimal representation of a 512-bit integer.",
-            "type":"string"
+          "U512": {
+            "description": "Decimal representation of a 512-bit integer.",
+            "type": "string"
           },
-          "URef":{
-            "description":"Hex-encoded, formatted URef.",
-            "type":"string"
+          "URef": {
+            "description": "Hex-encoded, formatted URef.",
+            "type": "string"
           },
-          "UnbondingPurse":{
-            "additionalProperties":false,
-            "description":"Unbonding purse.",
-            "properties":{
-              "amount":{
-                "allOf":[
+          "UnbondingPurse": {
+            "additionalProperties": false,
+            "description": "Unbonding purse.",
+            "properties": {
+              "amount": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/U512"
+                    "$ref": "#/components/schemas/U512"
                   }
                 ],
-                "description":"Unbonding Amount."
+                "description": "Unbonding Amount."
               },
-              "bonding_purse":{
-                "allOf":[
+              "bonding_purse": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/URef"
+                    "$ref": "#/components/schemas/URef"
                   }
                 ],
-                "description":"Bonding Purse"
+                "description": "Bonding Purse"
               },
-              "era_of_creation":{
-                "allOf":[
+              "era_of_creation": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/EraId"
+                    "$ref": "#/components/schemas/EraId"
                   }
                 ],
-                "description":"Era in which this unbonding request was created."
+                "description": "Era in which this unbonding request was created."
               },
-              "unbonder_public_key":{
-                "allOf":[
+              "unbonder_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Unbonders public key."
+                "description": "Unbonders public key."
               },
-              "validator_public_key":{
-                "allOf":[
+              "validator_public_key": {
+                "allOf": [
                   {
-                    "$ref":"#/components/schemas/PublicKey"
+                    "$ref": "#/components/schemas/PublicKey"
                   }
                 ],
-                "description":"Validators public key."
+                "description": "Validators public key."
               }
             },
-            "required":[
+            "required": [
               "amount",
               "bonding_purse",
               "era_of_creation",
               "unbonder_public_key",
               "validator_public_key"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "ValidatorChange":{
-            "description":"A change to a validator's status between two eras.",
-            "enum":[
+          "ValidatorChange": {
+            "description": "A change to a validator's status between two eras.",
+            "enum": [
               "Added",
               "Removed",
               "Banned",
               "CannotPropose",
               "SeenAsFaulty"
             ],
-            "type":"string"
+            "type": "string"
           },
-          "ValidatorWeight":{
-            "additionalProperties":false,
-            "properties":{
-              "validator":{
-                "$ref":"#/components/schemas/PublicKey"
+          "ValidatorWeight": {
+            "additionalProperties": false,
+            "properties": {
+              "validator": {
+                "$ref": "#/components/schemas/PublicKey"
               },
-              "weight":{
-                "$ref":"#/components/schemas/U512"
+              "weight": {
+                "$ref": "#/components/schemas/U512"
               }
             },
-            "required":[
+            "required": [
               "validator",
               "weight"
             ],
-            "type":"object"
+            "type": "object"
           },
-          "VestingSchedule":{
-            "additionalProperties":false,
-            "properties":{
-              "initial_release_timestamp_millis":{
-                "format":"uint64",
-                "minimum":0.0,
-                "type":"integer"
+          "VestingSchedule": {
+            "additionalProperties": false,
+            "properties": {
+              "initial_release_timestamp_millis": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
               },
-              "locked_amounts":{
-                "items":{
-                  "$ref":"#/components/schemas/U512"
+              "locked_amounts": {
+                "items": {
+                  "$ref": "#/components/schemas/U512"
                 },
-                "maxItems":14,
-                "minItems":14,
-                "type":[
+                "maxItems": 14,
+                "minItems": 14,
+                "type": [
                   "array",
                   "null"
                 ]
               }
             },
-            "required":[
+            "required": [
               "initial_release_timestamp_millis"
             ],
-            "type":"object"
+            "type": "object"
           }
         }
       },
-      "info":{
-        "contact":{
-          "name":"CasperLabs",
-          "url":"https://casperlabs.io"
+      "info": {
+        "contact": {
+          "name": "CasperLabs",
+          "url": "https://casperlabs.io"
         },
-        "description":"This describes the JSON-RPC 2.0 API of a node on the Casper network.",
-        "license":{
-          "name":"CasperLabs Open Source License Version 1.0",
-          "url":"https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
+        "description": "This describes the JSON-RPC 2.0 API of a node on the Casper network.",
+        "license": {
+          "name": "CasperLabs Open Source License Version 1.0",
+          "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
-        "title":"Client API of Casper Node",
-        "version":"1.3.2"
+        "title": "Client API of Casper Node",
+        "version": "1.3.2"
       },
-      "methods":[
+      "methods": [
         {
-          "examples":[
+          "examples": [
             {
-              "name":"account_put_deploy_example",
-              "params":[
+              "name": "account_put_deploy_example",
+              "params": [
                 {
-                  "name":"deploy",
-                  "value":{
-                    "approvals":[
+                  "name": "deploy",
+                  "value": {
+                    "approvals": [
                       {
-                        "signature":"012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
-                        "signer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+                        "signature": "012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                       }
                     ],
-                    "hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
-                    "header":{
-                      "account":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "body_hash":"d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name":"casper-example",
-                      "dependencies":[
+                    "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
+                    "header": {
+                      "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
+                      "chain_name": "casper-example",
+                      "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price":1,
-                      "timestamp":"2020-11-17T00:39:24.072Z",
-                      "ttl":"1h"
+                      "gas_price": 1,
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h"
                     },
-                    "payment":{
-                      "StoredContractByName":{
-                        "args":[
+                    "payment": {
+                      "StoredContractByName": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ],
-                        "entry_point":"example-entry-point",
-                        "name":"casper-example"
+                        "entry_point": "example-entry-point",
+                        "name": "casper-example"
                       }
                     },
-                    "session":{
-                      "Transfer":{
-                        "args":[
+                    "session": {
+                      "Transfer": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ]
@@ -2734,145 +2734,145 @@
                   }
                 }
               ],
-              "result":{
-                "name":"account_put_deploy_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "deploy_hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
+              "result": {
+                "name": "account_put_deploy_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
             }
           ],
-          "name":"account_put_deploy",
-          "params":[
+          "name": "account_put_deploy",
+          "params": [
             {
-              "name":"deploy",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Deploy",
-                "description":"The `Deploy`."
+              "name": "deploy",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Deploy",
+                "description": "The `Deploy`."
               }
             }
           ],
-          "result":{
-            "name":"account_put_deploy_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"account_put_deploy\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "account_put_deploy_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"account_put_deploy\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "deploy_hash":{
-                  "$ref":"#/components/schemas/DeployHash",
-                  "description":"The deploy hash."
+                "deploy_hash": {
+                  "$ref": "#/components/schemas/DeployHash",
+                  "description": "The deploy hash."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "deploy_hash"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"receives a Deploy to be executed by the network"
+          "summary": "receives a Deploy to be executed by the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_deploy_example",
-              "params":[
+              "name": "info_get_deploy_example",
+              "params": [
                 {
-                  "name":"deploy_hash",
-                  "value":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
+                  "name": "deploy_hash",
+                  "value": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               ],
-              "result":{
-                "name":"info_get_deploy_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "deploy":{
-                    "approvals":[
+              "result": {
+                "name": "info_get_deploy_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "deploy": {
+                    "approvals": [
                       {
-                        "signature":"012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
-                        "signer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+                        "signature": "012dbf03817a51794a8e19e0724884075e6d1fbec326b766ecfa6658b41f81290da85e23b24e88b1c8d9761185c961daee1adab0649912a6477bcd2e69bd91bd08",
+                        "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                       }
                     ],
-                    "hash":"5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
-                    "header":{
-                      "account":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "body_hash":"d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-                      "chain_name":"casper-example",
-                      "dependencies":[
+                    "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
+                    "header": {
+                      "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
+                      "chain_name": "casper-example",
+                      "dependencies": [
                         "0101010101010101010101010101010101010101010101010101010101010101"
                       ],
-                      "gas_price":1,
-                      "timestamp":"2020-11-17T00:39:24.072Z",
-                      "ttl":"1h"
+                      "gas_price": 1,
+                      "timestamp": "2020-11-17T00:39:24.072Z",
+                      "ttl": "1h"
                     },
-                    "payment":{
-                      "StoredContractByName":{
-                        "args":[
+                    "payment": {
+                      "StoredContractByName": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ],
-                        "entry_point":"example-entry-point",
-                        "name":"casper-example"
+                        "entry_point": "example-entry-point",
+                        "name": "casper-example"
                       }
                     },
-                    "session":{
-                      "Transfer":{
-                        "args":[
+                    "session": {
+                      "Transfer": {
+                        "args": [
                           [
                             "amount",
                             {
-                              "bytes":"e8030000",
-                              "cl_type":"I32",
-                              "parsed":1000
+                              "bytes": "e8030000",
+                              "cl_type": "I32",
+                              "parsed": 1000
                             }
                           ]
                         ]
                       }
                     }
                   },
-                  "execution_results":[
+                  "execution_results": [
                     {
-                      "block_hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
-                      "result":{
-                        "Success":{
-                          "cost":"123456",
-                          "effect":{
-                            "operations":[
+                      "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
+                      "result": {
+                        "Success": {
+                          "cost": "123456",
+                          "effect": {
+                            "operations": [
                               {
-                                "key":"account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
-                                "kind":"Write"
+                                "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+                                "kind": "Write"
                               },
                               {
-                                "key":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                                "kind":"Read"
+                                "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                                "kind": "Read"
                               }
                             ],
-                            "transforms":[
+                            "transforms": [
                               {
-                                "key":"uref-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb-007",
-                                "transform":{
-                                  "AddUInt64":8
+                                "key": "uref-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb-007",
+                                "transform": {
+                                  "AddUInt64": 8
                                 }
                               },
                               {
-                                "key":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                                "transform":"Identity"
+                                "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                                "transform": "Identity"
                               }
                             ]
                           },
-                          "transfers":[
+                          "transfers": [
                             "transfer-5959595959595959595959595959595959595959595959595959595959595959",
                             "transfer-8282828282828282828282828282828282828282828282828282828282828282"
                           ]
@@ -2884,567 +2884,551 @@
               }
             }
           ],
-          "name":"info_get_deploy",
-          "params":[
+          "name": "info_get_deploy",
+          "params": [
             {
-              "name":"deploy_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/DeployHash",
-                "description":"The deploy hash."
+              "name": "deploy_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/DeployHash",
+                "description": "The deploy hash."
               }
             }
           ],
-          "result":{
-            "name":"info_get_deploy_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_deploy\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "info_get_deploy_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_deploy\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "deploy":{
-                  "$ref":"#/components/schemas/Deploy",
-                  "description":"The deploy."
+                "deploy": {
+                  "$ref": "#/components/schemas/Deploy",
+                  "description": "The deploy."
                 },
-                "execution_results":{
-                  "description":"The map of block hash to execution result.",
-                  "items":{
-                    "$ref":"#/components/schemas/JsonExecutionResult"
+                "execution_results": {
+                  "description": "The map of block hash to execution result.",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonExecutionResult"
                   },
-                  "type":"array"
+                  "type": "array"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "deploy",
                 "execution_results"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a Deploy from the network"
+          "summary": "returns a Deploy from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_account_info_example",
-              "params":[
+              "name": "state_get_account_info_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 },
                 {
-                  "name":"public_key",
-                  "value":"013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
+                  "name": "public_key",
+                  "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                 }
               ],
-              "result":{
-                "name":"state_get_account_info_example_result",
-                "value":{
-                  "account":{
-                    "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                    "action_thresholds":{
-                      "deployment":1,
-                      "key_management":1
+              "result": {
+                "name": "state_get_account_info_example_result",
+                "value": {
+                  "account": {
+                    "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                    "action_thresholds": {
+                      "deployment": 1,
+                      "key_management": 1
                     },
-                    "associated_keys":[
+                    "associated_keys": [
                       {
-                        "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                        "weight":1
+                        "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                        "weight": 1
                       }
                     ],
-                    "main_purse":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                    "named_keys":[
-
-                    ]
+                    "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                    "named_keys": []
                   },
-                  "api_version":"1.3.2",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+                  "api_version": "1.3.2",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
           ],
-          "name":"state_get_account_info",
-          "params":[
+          "name": "state_get_account_info",
+          "params": [
             {
-              "name":"public_key",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/PublicKey",
-                "description":"The public key of the Account."
+              "name": "public_key",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/PublicKey",
+                "description": "The public key of the Account."
               }
             },
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "anyOf":[
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "anyOf": [
                   {
-                    "$ref":"#/components/schemas/BlockIdentifier"
+                    "$ref": "#/components/schemas/BlockIdentifier"
                   },
                   {
-                    "type":"null"
+                    "type": "null"
                   }
                 ],
-                "description":"The block identifier."
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_account_info_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_account_info\" RPC response.",
-              "properties":{
-                "account":{
-                  "$ref":"#/components/schemas/Account",
-                  "description":"The account."
+          "result": {
+            "name": "state_get_account_info_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_account_info\" RPC response.",
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account",
+                  "description": "The account."
                 },
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 }
               },
-              "required":[
+              "required": [
                 "account",
                 "api_version",
                 "merkle_proof"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an Account from the network"
+          "summary": "returns an Account from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_dictionary_item_example",
-              "params":[
+              "name": "state_get_dictionary_item_example",
+              "params": [
                 {
-                  "name":"dictionary_identifier",
-                  "value":{
-                    "URef":{
-                      "dictionary_item_key":"a_unique_entry_identifier",
-                      "seed_uref":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
+                  "name": "dictionary_identifier",
+                  "value": {
+                    "URef": {
+                      "dictionary_item_key": "a_unique_entry_identifier",
+                      "seed_uref": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
                     }
                   }
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_dictionary_item_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "dictionary_key":"dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "CLValue":{
-                      "bytes":"0100000000000000",
-                      "cl_type":"U64",
-                      "parsed":1
+              "result": {
+                "name": "state_get_dictionary_item_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "CLValue": {
+                      "bytes": "0100000000000000",
+                      "cl_type": "U64",
+                      "parsed": 1
                     }
                   }
                 }
               }
             }
           ],
-          "name":"state_get_dictionary_item",
-          "params":[
+          "name": "state_get_dictionary_item",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"Hash of the state root"
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "Hash of the state root"
               }
             },
             {
-              "name":"dictionary_identifier",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/DictionaryIdentifier",
-                "description":"The Dictionary query identifier."
+              "name": "dictionary_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/DictionaryIdentifier",
+                "description": "The Dictionary query identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_dictionary_item_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_dictionary_item\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_dictionary_item_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_dictionary_item\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "dictionary_key":{
-                  "description":"The key under which the value is stored.",
-                  "type":"string"
+                "dictionary_key": {
+                  "description": "The key under which the value is stored.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "dictionary_key",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an item from a Dictionary"
+          "summary": "returns an item from a Dictionary"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"query_global_state_example",
-              "params":[
+              "name": "query_global_state_example",
+              "params": [
                 {
-                  "name":"key",
-                  "value":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
+                  "name": "key",
+                  "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
                 },
                 {
-                  "name":"path",
-                  "value":[
-
-                  ]
+                  "name": "path",
+                  "value": []
                 },
                 {
-                  "name":"state_identifier",
-                  "value":{
-                    "BlockHash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "state_identifier",
+                  "value": {
+                    "BlockHash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 }
               ],
-              "result":{
-                "name":"query_global_state_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block_header":{
-                    "accumulated_seed":"ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
-                    "body_hash":"8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
-                    "era_end":{
-                      "era_report":{
-                        "equivocators":[
+              "result": {
+                "name": "query_global_state_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block_header": {
+                    "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                    "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
+                    "era_end": {
+                      "era_report": {
+                        "equivocators": [
                           "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                         ],
-                        "inactive_validators":[
+                        "inactive_validators": [
                           "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                         ],
-                        "rewards":[
+                        "rewards": [
                           {
-                            "amount":1000,
-                            "validator":"018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                            "amount": 1000,
+                            "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
                           }
                         ]
                       },
-                      "next_era_validator_weights":[
+                      "next_era_validator_weights": [
                         {
-                          "validator":"016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
-                          "weight":"456"
+                          "validator": "016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
+                          "weight": "456"
                         },
                         {
-                          "validator":"018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
-                          "weight":"789"
+                          "validator": "018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
+                          "weight": "789"
                         },
                         {
-                          "validator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                          "weight":"123"
+                          "validator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                          "weight": "123"
                         }
                       ]
                     },
-                    "era_id":1,
-                    "height":10,
-                    "parent_hash":"0707070707070707070707070707070707070707070707070707070707070707",
-                    "protocol_version":"1.0.0",
-                    "random_bit":true,
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp":"2020-11-17T00:39:24.072Z"
+                    "era_id": 1,
+                    "height": 10,
+                    "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                    "protocol_version": "1.0.0",
+                    "random_bit": true,
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "timestamp": "2020-11-17T00:39:24.072Z"
                   },
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "Account":{
-                      "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                      "action_thresholds":{
-                        "deployment":1,
-                        "key_management":1
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "Account": {
+                      "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                      "action_thresholds": {
+                        "deployment": 1,
+                        "key_management": 1
                       },
-                      "associated_keys":[
+                      "associated_keys": [
                         {
-                          "account_hash":"account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-                          "weight":1
+                          "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+                          "weight": 1
                         }
                       ],
-                      "main_purse":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-                      "named_keys":[
-
-                      ]
+                      "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+                      "named_keys": []
                     }
                   }
                 }
               }
             }
           ],
-          "name":"query_global_state",
-          "params":[
+          "name": "query_global_state",
+          "params": [
             {
-              "name":"state_identifier",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/GlobalStateIdentifier",
-                "description":"The identifier used for the query."
+              "name": "state_identifier",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/GlobalStateIdentifier",
+                "description": "The identifier used for the query."
               }
             },
             {
-              "name":"key",
-              "required":true,
-              "schema":{
-                "description":"`casper_types::Key` as formatted string.",
-                "type":"string"
+              "name": "key",
+              "required": true,
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
               }
             },
             {
-              "name":"path",
-              "required":false,
-              "schema":{
-                "default":[
-
-                ],
-                "description":"The path components starting from the key as base.",
-                "items":{
-                  "type":"string"
+              "name": "path",
+              "required": false,
+              "schema": {
+                "default": [],
+                "description": "The path components starting from the key as base.",
+                "items": {
+                  "type": "string"
                 },
-                "type":"array"
+                "type": "array"
               }
             }
           ],
-          "result":{
-            "name":"query_global_state_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"query_global_state\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "query_global_state_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"query_global_state\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block_header":{
-                  "anyOf":[
+                "block_header": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/JsonBlockHeader"
+                      "$ref": "#/components/schemas/JsonBlockHeader"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block header if a Block hash was provided."
+                  "description": "The block header if a Block hash was provided."
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"a query to global state using either a Block hash or state root hash"
+          "summary": "a query to global state using either a Block hash or state root hash"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_peers_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_peers_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "peers":[
+              "name": "info_get_peers_example",
+              "params": [],
+              "result": {
+                "name": "info_get_peers_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "peers": [
                     {
-                      "address":"127.0.0.1:54321",
-                      "node_id":"tls:0101..0101"
+                      "address": "127.0.0.1:54321",
+                      "node_id": "tls:0101..0101"
                     }
                   ]
                 }
               }
             }
           ],
-          "name":"info_get_peers",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_peers_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_peers\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_peers",
+          "params": [],
+          "result": {
+            "name": "info_get_peers_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_peers\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "peers":{
-                  "$ref":"#/components/schemas/PeersMap",
-                  "description":"The node ID and network address of each connected peer."
+                "peers": {
+                  "$ref": "#/components/schemas/PeersMap",
+                  "description": "The node ID and network address of each connected peer."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "peers"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a list of peers connected to the node"
+          "summary": "returns a list of peers connected to the node"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_status_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_status_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "build_version":"1.0.0-xxxxxxxxx@DEBUG",
-                  "chainspec_name":"casper-example",
-                  "last_added_block_info":{
-                    "creator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                    "era_id":1,
-                    "hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
-                    "height":10,
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "timestamp":"2020-11-17T00:39:24.072Z"
+              "name": "info_get_status_example",
+              "params": [],
+              "result": {
+                "name": "info_get_status_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "build_version": "1.0.0-xxxxxxxxx@DEBUG",
+                  "chainspec_name": "casper-example",
+                  "last_added_block_info": {
+                    "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                    "era_id": 1,
+                    "hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
+                    "height": 10,
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "timestamp": "2020-11-17T00:39:24.072Z"
                   },
-                  "next_upgrade":{
-                    "activation_point":42,
-                    "protocol_version":"2.0.1"
+                  "next_upgrade": {
+                    "activation_point": 42,
+                    "protocol_version": "2.0.1"
                   },
-                  "our_public_signing_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                  "peers":[
+                  "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                  "peers": [
                     {
-                      "address":"127.0.0.1:54321",
-                      "node_id":"tls:0101..0101"
+                      "address": "127.0.0.1:54321",
+                      "node_id": "tls:0101..0101"
                     }
                   ],
-                  "round_length":"1m 5s 536ms",
-                  "starting_state_root_hash":"0202020202020202020202020202020202020202020202020202020202020202",
-                  "uptime":"13s"
+                  "round_length": "1m 5s 536ms",
+                  "starting_state_root_hash": "0202020202020202020202020202020202020202020202020202020202020202",
+                  "uptime": "13s"
                 }
               }
             }
           ],
-          "name":"info_get_status",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_status_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"info_get_status\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_status",
+          "params": [],
+          "result": {
+            "name": "info_get_status_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"info_get_status\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "build_version":{
-                  "description":"The compiled node version.",
-                  "type":"string"
+                "build_version": {
+                  "description": "The compiled node version.",
+                  "type": "string"
                 },
-                "chainspec_name":{
-                  "description":"The chainspec name.",
-                  "type":"string"
+                "chainspec_name": {
+                  "description": "The chainspec name.",
+                  "type": "string"
                 },
-                "last_added_block_info":{
-                  "anyOf":[
+                "last_added_block_info": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/MinimalBlockInfo"
+                      "$ref": "#/components/schemas/MinimalBlockInfo"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The minimal info of the last block from the linear chain."
+                  "description": "The minimal info of the last block from the linear chain."
                 },
-                "next_upgrade":{
-                  "anyOf":[
+                "next_upgrade": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/NextUpgrade"
+                      "$ref": "#/components/schemas/NextUpgrade"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Information about the next scheduled upgrade."
+                  "description": "Information about the next scheduled upgrade."
                 },
-                "our_public_signing_key":{
-                  "anyOf":[
+                "our_public_signing_key": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/PublicKey"
+                      "$ref": "#/components/schemas/PublicKey"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Our public signing key."
+                  "description": "Our public signing key."
                 },
-                "peers":{
-                  "$ref":"#/components/schemas/PeersMap",
-                  "description":"The node ID and network address of each connected peer."
+                "peers": {
+                  "$ref": "#/components/schemas/PeersMap",
+                  "description": "The node ID and network address of each connected peer."
                 },
-                "round_length":{
-                  "anyOf":[
+                "round_length": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/TimeDiff"
+                      "$ref": "#/components/schemas/TimeDiff"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The next round length if this node is a validator."
+                  "description": "The next round length if this node is a validator."
                 },
-                "starting_state_root_hash":{
-                  "$ref":"#/components/schemas/Digest",
-                  "description":"The state root hash used at the start of the current session."
+                "starting_state_root_hash": {
+                  "$ref": "#/components/schemas/Digest",
+                  "description": "The state root hash used at the start of the current session."
                 },
-                "uptime":{
-                  "$ref":"#/components/schemas/TimeDiff",
-                  "description":"Time that passed since the node has started."
+                "uptime": {
+                  "$ref": "#/components/schemas/TimeDiff",
+                  "description": "Time that passed since the node has started."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "build_version",
                 "chainspec_name",
@@ -3452,29 +3436,27 @@
                 "starting_state_root_hash",
                 "uptime"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns the current status of the node"
+          "summary": "returns the current status of the node"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"info_get_validator_changes_example",
-              "params":[
-
-              ],
-              "result":{
-                "name":"info_get_validator_changes_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "changes_to_validators":[
+              "name": "info_get_validator_changes_example",
+              "params": [],
+              "result": {
+                "name": "info_get_validator_changes_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "changes": [
                     {
-                      "public_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "status_changes":[
+                      "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "status_changes": [
                         {
-                          "era_id":1,
-                          "validator_change":"Added"
+                          "era_id": 1,
+                          "validator_change": "Added"
                         }
                       ]
                     }
@@ -3483,109 +3465,105 @@
               }
             }
           ],
-          "name":"info_get_validator_changes",
-          "params":[
-
-          ],
-          "result":{
-            "name":"info_get_validator_changes_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for the \"info_get_validator_changes\" RPC.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "name": "info_get_validator_changes",
+          "params": [],
+          "result": {
+            "name": "info_get_validator_changes_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for the \"info_get_validator_changes\" RPC.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "changes_to_validators":{
-                  "description":"The validator information.",
-                  "items":{
-                    "$ref":"#/components/schemas/JsonValidatorInfo"
+                "changes": {
+                  "description": "The validators' status changes.",
+                  "items": {
+                    "$ref": "#/components/schemas/JsonValidatorChanges"
                   },
-                  "type":"array"
+                  "type": "array"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
-                "changes_to_validators"
+                "changes"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns changes in validator status between any two eras"
+          "summary": "returns status changes of active validators"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_block_example",
-              "params":[
+              "name": "chain_get_block_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_block_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block":{
-                    "body":{
-                      "deploy_hashes":[
+              "result": {
+                "name": "chain_get_block_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block": {
+                    "body": {
+                      "deploy_hashes": [
                         "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                       ],
-                      "proposer":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "transfer_hashes":[
-
-                      ]
+                      "proposer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                      "transfer_hashes": []
                     },
-                    "hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
-                    "header":{
-                      "accumulated_seed":"ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
-                      "body_hash":"8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
-                      "era_end":{
-                        "era_report":{
-                          "equivocators":[
+                    "hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
+                    "header": {
+                      "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
+                      "body_hash": "8472b18539dc204cf7cb0520bb5c3a91c1551a5c258189a61a15d3a2a35f1763",
+                      "era_end": {
+                        "era_report": {
+                          "equivocators": [
                             "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
                           ],
-                          "inactive_validators":[
+                          "inactive_validators": [
                             "018139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
                           ],
-                          "rewards":[
+                          "rewards": [
                             {
-                              "amount":1000,
-                              "validator":"018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+                              "amount": 1000,
+                              "validator": "018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
                             }
                           ]
                         },
-                        "next_era_validator_weights":[
+                        "next_era_validator_weights": [
                           {
-                            "validator":"016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
-                            "weight":"456"
+                            "validator": "016e7a1cdd29b0b78fd13af4c5598feff4ef2a97166e3ca6f2e4fbfccd80505bf1",
+                            "weight": "456"
                           },
                           {
-                            "validator":"018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
-                            "weight":"789"
+                            "validator": "018a875fff1eb38451577acd5afee405456568dd7c89e090863a0557bc7af49f17",
+                            "weight": "789"
                           },
                           {
-                            "validator":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                            "weight":"123"
+                            "validator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                            "weight": "123"
                           }
                         ]
                       },
-                      "era_id":1,
-                      "height":10,
-                      "parent_hash":"0707070707070707070707070707070707070707070707070707070707070707",
-                      "protocol_version":"1.0.0",
-                      "random_bit":true,
-                      "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                      "timestamp":"2020-11-17T00:39:24.072Z"
+                      "era_id": 1,
+                      "height": 10,
+                      "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
+                      "protocol_version": "1.0.0",
+                      "random_bit": true,
+                      "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                      "timestamp": "2020-11-17T00:39:24.072Z"
                     },
-                    "proofs":[
+                    "proofs": [
                       {
-                        "public_key":"01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                        "signature":"016674d7b8c8534c72cab425590593595883c4ebb88397a6fc035768abfd8b8864cbdbf1310d66c5d0f65a70054a81a5cad1366a6511856e1e7036814dbd34a309"
+                        "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+                        "signature": "016674d7b8c8534c72cab425590593595883c4ebb88397a6fc035768abfd8b8864cbdbf1310d66c5d0f65a70054a81a5cad1366a6511856e1e7036814dbd34a309"
                       }
                     ]
                   }
@@ -3593,398 +3571,396 @@
               }
             }
           ],
-          "name":"chain_get_block",
-          "params":[
+          "name": "chain_get_block",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_block_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_block\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_block_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_block\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block":{
-                  "anyOf":[
+                "block": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/JsonBlock"
+                      "$ref": "#/components/schemas/JsonBlock"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block, if found."
+                  "description": "The block, if found."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a Block from the network"
+          "summary": "returns a Block from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_block_transfers_example",
-              "params":[
+              "name": "chain_get_block_transfers_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_block_transfers_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "block_hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
-                  "transfers":[
+              "result": {
+                "name": "chain_get_block_transfers_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
+                  "transfers": [
                     {
-                      "amount":"0",
-                      "deploy_hash":"0000000000000000000000000000000000000000000000000000000000000000",
-                      "from":"account-hash-0000000000000000000000000000000000000000000000000000000000000000",
-                      "gas":"0",
-                      "id":null,
-                      "source":"uref-0000000000000000000000000000000000000000000000000000000000000000-000",
-                      "target":"uref-0000000000000000000000000000000000000000000000000000000000000000-000",
-                      "to":null
+                      "amount": "0",
+                      "deploy_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                      "from": "account-hash-0000000000000000000000000000000000000000000000000000000000000000",
+                      "gas": "0",
+                      "id": null,
+                      "source": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
+                      "target": "uref-0000000000000000000000000000000000000000000000000000000000000000-000",
+                      "to": null
                     }
                   ]
                 }
               }
             }
           ],
-          "name":"chain_get_block_transfers",
-          "params":[
+          "name": "chain_get_block_transfers",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_block_transfers_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_block_transfers\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_block_transfers_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_block_transfers\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "block_hash":{
-                  "anyOf":[
+                "block_hash": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/BlockHash"
+                      "$ref": "#/components/schemas/BlockHash"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The block hash, if found."
+                  "description": "The block hash, if found."
                 },
-                "transfers":{
-                  "description":"The block's transfers, if found.",
-                  "items":{
-                    "$ref":"#/components/schemas/Transfer"
+                "transfers": {
+                  "description": "The block's transfers, if found.",
+                  "items": {
+                    "$ref": "#/components/schemas/Transfer"
                   },
-                  "type":[
+                  "type": [
                     "array",
                     "null"
                   ]
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns all transfers for a Block from the network"
+          "summary": "returns all transfers for a Block from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_state_root_hash_example",
-              "params":[
+              "name": "chain_get_state_root_hash_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Height":10
+                  "name": "block_identifier",
+                  "value": {
+                    "Height": 10
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_state_root_hash_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808"
+              "result": {
+                "name": "chain_get_state_root_hash_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
             }
           ],
-          "name":"chain_get_state_root_hash",
-          "params":[
+          "name": "chain_get_state_root_hash",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block hash."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block hash."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_state_root_hash_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_state_root_hash\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_state_root_hash_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_state_root_hash\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "state_root_hash":{
-                  "anyOf":[
+                "state_root_hash": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/Digest"
+                      "$ref": "#/components/schemas/Digest"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"Hex-encoded hash of the state root."
+                  "description": "Hex-encoded hash of the state root."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a state root hash at a given Block"
+          "summary": "returns a state root hash at a given Block"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_item_example",
-              "params":[
+              "name": "state_get_item_example",
+              "params": [
                 {
-                  "name":"key",
-                  "value":"deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
+                  "name": "key",
+                  "value": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1"
                 },
                 {
-                  "name":"path",
-                  "value":[
+                  "name": "path",
+                  "value": [
                     "inner"
                   ]
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_item_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                  "stored_value":{
-                    "CLValue":{
-                      "bytes":"0100000000000000",
-                      "cl_type":"U64",
-                      "parsed":1
+              "result": {
+                "name": "state_get_item_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                  "stored_value": {
+                    "CLValue": {
+                      "bytes": "0100000000000000",
+                      "cl_type": "U64",
+                      "parsed": 1
                     }
                   }
                 }
               }
             }
           ],
-          "name":"state_get_item",
-          "params":[
+          "name": "state_get_item",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"Hash of the state root."
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "Hash of the state root."
               }
             },
             {
-              "name":"key",
-              "required":true,
-              "schema":{
-                "description":"`casper_types::Key` as formatted string.",
-                "type":"string"
+              "name": "key",
+              "required": true,
+              "schema": {
+                "description": "`casper_types::Key` as formatted string.",
+                "type": "string"
               }
             },
             {
-              "name":"path",
-              "required":false,
-              "schema":{
-                "default":[
-
-                ],
-                "description":"The path components starting from the key as base.",
-                "items":{
-                  "type":"string"
+              "name": "path",
+              "required": false,
+              "schema": {
+                "default": [],
+                "description": "The path components starting from the key as base.",
+                "items": {
+                  "type": "string"
                 },
-                "type":"array"
+                "type": "array"
               }
             }
           ],
-          "result":{
-            "name":"state_get_item_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_item\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_item_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_item\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 },
-                "stored_value":{
-                  "$ref":"#/components/schemas/StoredValue",
-                  "description":"The stored value."
+                "stored_value": {
+                  "$ref": "#/components/schemas/StoredValue",
+                  "description": "The stored value."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "merkle_proof",
                 "stored_value"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead."
+          "summary": "returns a stored value from the network. This RPC is deprecated, use `query_global_state` instead."
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_balance_example",
-              "params":[
+              "name": "state_get_balance_example",
+              "params": [
                 {
-                  "name":"purse_uref",
-                  "value":"uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
+                  "name": "purse_uref",
+                  "value": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
                 },
                 {
-                  "name":"state_root_hash",
-                  "value":"0808080808080808080808080808080808080808080808080808080808080808"
+                  "name": "state_root_hash",
+                  "value": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               ],
-              "result":{
-                "name":"state_get_balance_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "balance_value":"123456",
-                  "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+              "result": {
+                "name": "state_get_balance_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "balance_value": "123456",
+                  "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
             }
           ],
-          "name":"state_get_balance",
-          "params":[
+          "name": "state_get_balance",
+          "params": [
             {
-              "name":"state_root_hash",
-              "required":true,
-              "schema":{
-                "$ref":"#/components/schemas/Digest",
-                "description":"The hash of state root."
+              "name": "state_root_hash",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/Digest",
+                "description": "The hash of state root."
               }
             },
             {
-              "name":"purse_uref",
-              "required":true,
-              "schema":{
-                "description":"Formatted URef.",
-                "type":"string"
+              "name": "purse_uref",
+              "required": true,
+              "schema": {
+                "description": "Formatted URef.",
+                "type": "string"
               }
             }
           ],
-          "result":{
-            "name":"state_get_balance_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_balance\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_balance_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_balance\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "balance_value":{
-                  "$ref":"#/components/schemas/U512",
-                  "description":"The balance value."
+                "balance_value": {
+                  "$ref": "#/components/schemas/U512",
+                  "description": "The balance value."
                 },
-                "merkle_proof":{
-                  "description":"The merkle proof.",
-                  "type":"string"
+                "merkle_proof": {
+                  "description": "The merkle proof.",
+                  "type": "string"
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "balance_value",
                 "merkle_proof"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns a purse's balance from the network"
+          "summary": "returns a purse's balance from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"chain_get_era_info_by_switch_block_example",
-              "params":[
+              "name": "chain_get_era_info_by_switch_block_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 }
               ],
-              "result":{
-                "name":"chain_get_era_info_by_switch_block_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "era_summary":{
-                    "block_hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
-                    "era_id":42,
-                    "merkle_proof":"01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
-                    "state_root_hash":"0808080808080808080808080808080808080808080808080808080808080808",
-                    "stored_value":{
-                      "EraInfo":{
-                        "seigniorage_allocations":[
+              "result": {
+                "name": "chain_get_era_info_by_switch_block_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "era_summary": {
+                    "block_hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d",
+                    "era_id": 42,
+                    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
+                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+                    "stored_value": {
+                      "EraInfo": {
+                        "seigniorage_allocations": [
                           {
-                            "Delegator":{
-                              "amount":"1000",
-                              "delegator_public_key":"01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18",
-                              "validator_public_key":"012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                            "Delegator": {
+                              "amount": "1000",
+                              "delegator_public_key": "01e1b46a25baa8a5c28beb3c9cfb79b572effa04076f00befa57eb70b016153f18",
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
                             }
                           },
                           {
-                            "Validator":{
-                              "amount":"2000",
-                              "validator_public_key":"012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
+                            "Validator": {
+                              "amount": "2000",
+                              "validator_public_key": "012a1732addc639ea43a89e25d3ad912e40232156dcaa4b9edfc709f43d2fb0876"
                             }
                           }
                         ]
@@ -3995,206 +3971,204 @@
               }
             }
           ],
-          "name":"chain_get_era_info_by_switch_block",
-          "params":[
+          "name": "chain_get_era_info_by_switch_block",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block identifier."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"chain_get_era_info_by_switch_block_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"chain_get_era_info\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "chain_get_era_info_by_switch_block_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"chain_get_era_info\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "era_summary":{
-                  "anyOf":[
+                "era_summary": {
+                  "anyOf": [
                     {
-                      "$ref":"#/components/schemas/EraSummary"
+                      "$ref": "#/components/schemas/EraSummary"
                     },
                     {
-                      "type":"null"
+                      "type": "null"
                     }
                   ],
-                  "description":"The era summary."
+                  "description": "The era summary."
                 }
               },
-              "required":[
+              "required": [
                 "api_version"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns an EraInfo from the network"
+          "summary": "returns an EraInfo from the network"
         },
         {
-          "examples":[
+          "examples": [
             {
-              "name":"state_get_auction_info_example",
-              "params":[
+              "name": "state_get_auction_info_example",
+              "params": [
                 {
-                  "name":"block_identifier",
-                  "value":{
-                    "Hash":"6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
+                  "name": "block_identifier",
+                  "value": {
+                    "Hash": "6b5db3585233ed0076910d3a81fa7d23fc4325f35e06d31f293043aef3f4c98d"
                   }
                 }
               ],
-              "result":{
-                "name":"state_get_auction_info_example_result",
-                "value":{
-                  "api_version":"1.3.2",
-                  "auction_state":{
-                    "bids":[
+              "result": {
+                "name": "state_get_auction_info_example_result",
+                "value": {
+                  "api_version": "1.3.2",
+                  "auction_state": {
+                    "bids": [
                       {
-                        "bid":{
-                          "bonding_purse":"uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
-                          "delegation_rate":0,
-                          "delegators":[
-
-                          ],
-                          "inactive":false,
-                          "staked_amount":"10"
+                        "bid": {
+                          "bonding_purse": "uref-fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa-007",
+                          "delegation_rate": 0,
+                          "delegators": [],
+                          "inactive": false,
+                          "staked_amount": "10"
                         },
-                        "public_key":"01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
+                        "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
                       }
                     ],
-                    "block_height":10,
-                    "era_validators":[
+                    "block_height": 10,
+                    "era_validators": [
                       {
-                        "era_id":10,
-                        "validator_weights":[
+                        "era_id": 10,
+                        "validator_weights": [
                           {
-                            "public_key":"01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
-                            "weight":"10"
+                            "public_key": "01197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+                            "weight": "10"
                           }
                         ]
                       }
                     ],
-                    "state_root_hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+                    "state_root_hash": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
                   }
                 }
               }
             }
           ],
-          "name":"state_get_auction_info",
-          "params":[
+          "name": "state_get_auction_info",
+          "params": [
             {
-              "name":"block_identifier",
-              "required":false,
-              "schema":{
-                "$ref":"#/components/schemas/BlockIdentifier",
-                "description":"The block identifier."
+              "name": "block_identifier",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/BlockIdentifier",
+                "description": "The block identifier."
               }
             }
           ],
-          "result":{
-            "name":"state_get_auction_info_result",
-            "schema":{
-              "additionalProperties":false,
-              "description":"Result for \"state_get_auction_info\" RPC response.",
-              "properties":{
-                "api_version":{
-                  "description":"The RPC API version.",
-                  "type":"string"
+          "result": {
+            "name": "state_get_auction_info_result",
+            "schema": {
+              "additionalProperties": false,
+              "description": "Result for \"state_get_auction_info\" RPC response.",
+              "properties": {
+                "api_version": {
+                  "description": "The RPC API version.",
+                  "type": "string"
                 },
-                "auction_state":{
-                  "$ref":"#/components/schemas/AuctionState",
-                  "description":"The auction state."
+                "auction_state": {
+                  "$ref": "#/components/schemas/AuctionState",
+                  "description": "The auction state."
                 }
               },
-              "required":[
+              "required": [
                 "api_version",
                 "auction_state"
               ],
-              "type":"object"
+              "type": "object"
             }
           },
-          "summary":"returns the bids and validators as of either a specific block (by height or hash), or the most recently added block"
+          "summary": "returns the bids and validators as of either a specific block (by height or hash), or the most recently added block"
         }
       ],
-      "openrpc":"1.0.0-rc1",
-      "servers":[
+      "openrpc": "1.0.0-rc1",
+      "servers": [
         {
-          "name":"any Casper Network node",
-          "url":"http://IP:PORT/rpc/"
+          "name": "any Casper Network node",
+          "url": "http://IP:PORT/rpc/"
         }
       ]
     }
   ],
-  "type":"object",
-  "properties":{
-    "openrpc":{
-      "type":"string"
+  "type": "object",
+  "properties": {
+    "openrpc": {
+      "type": "string"
     },
-    "info":{
-      "type":"object",
-      "properties":{
-        "version":{
-          "type":"string"
+    "info": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
         },
-        "title":{
-          "type":"string"
+        "title": {
+          "type": "string"
         },
-        "description":{
-          "type":"string"
+        "description": {
+          "type": "string"
         },
-        "contact":{
-          "type":"object",
-          "properties":{
-            "name":{
-              "type":"string"
+        "contact": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "url":{
-              "type":"string"
+            "url": {
+              "type": "string"
             }
           }
         },
-        "license":{
-          "type":"object",
-          "properties":{
-            "name":{
-              "type":"string"
+        "license": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "url":{
-              "type":"string"
+            "url": {
+              "type": "string"
             }
           }
         }
       }
     },
-    "servers":{
-      "type":"array",
-      "items":{
-        "type":"object",
-        "properties":{
-          "name":{
-            "type":"string"
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "url":{
-            "type":"string"
+          "url": {
+            "type": "string"
           }
         }
       }
     },
-    "methods":{
-      "type":"array",
-      "items":true
+    "methods": {
+      "type": "array",
+      "items": true
     },
-    "components":{
-      "type":"object",
-      "properties":{
-        "schemas":{
-          "type":"object",
-          "additionalProperties":true
+    "components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     }

--- a/resources/test/rpc_schema_hashing_V2.json
+++ b/resources/test/rpc_schema_hashing_V2.json
@@ -1610,7 +1610,7 @@
             ],
             "type": "object"
           },
-          "JsonEraChange": {
+          "JsonValidatorStatusChange": {
             "additionalProperties": false,
             "description": "A single change to a validator's status in the given era.",
             "properties": {
@@ -1765,7 +1765,7 @@
               "status_changes": {
                 "description": "The set of changes to the validator's status.",
                 "items": {
-                  "$ref": "#/components/schemas/JsonEraChange"
+                  "$ref": "#/components/schemas/JsonValidatorStatusChange"
                 },
                 "type": "array"
               }


### PR DESCRIPTION
This has the following changes:
* added further unit tests
* refactored main `ValidatorChange` function to use hashset differences rather than for loops
* deduplicated the logic for constructing a `GetValidatorChangesResult`
* replaced term "between two eras" as discussed offline
* other minor nitpicks