### PR TITLE
Changed several details of the chainspec registry and how its handled

### DIFF
--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -14,13 +14,14 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Added a new entry point `redelegate` to the Auction system contract which allows users to redelegate to another validator without having to unbond. The function signature for the entrypoint is: `redelegate(delegator: PublicKey, validator: PublicKey, amount: U512, new_validator: PublicKey)`
-* Added a new type `ChainspecRegistry` which contains the hashes of the `chainspec.toml` and will optionally contain the hashes for `accounts.toml` and `global_state.toml`.
+* Add a new entry point `redelegate` to the Auction system contract which allows users to redelegate to another validator without having to unbond. The function signature for the entrypoint is: `redelegate(delegator: PublicKey, validator: PublicKey, amount: U512, new_validator: PublicKey)`
+* Add a new type `ChainspecRegistry` which contains the hashes of the `chainspec.toml` and will optionally contain the hashes for `accounts.toml` and `global_state.toml`.
 
 ### Changed
-* (Perf) Changed contract runtime to allow caching GlobalState changes during execution of a single block.
-* Fixed some integer casts.
-* Changed both genesis and upgrade functions to write `ChainspecRegistry` under the fixed `Key::ChainspecRegistry`.
+* Change contract runtime to allow caching GlobalState changes during execution of a single block.
+* Fix some integer casts.
+* Change both genesis and upgrade functions to write `ChainspecRegistry` under the fixed `Key::ChainspecRegistry`.
+
 
 
 ## 1.4.3 - 2021-12-06

--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -6,11 +6,6 @@ pub mod runtime;
 pub mod runtime_context;
 pub(crate) mod tracking_copy;
 
-use std::collections::BTreeMap;
-
-use casper_hashing::Digest;
-use casper_types::ContractHash;
-
 pub use tracking_copy::{validate_balance_proof, validate_query_proof, ValidationError};
 
 /// The length of an address.
@@ -18,16 +13,3 @@ pub const ADDRESS_LENGTH: usize = 32;
 
 /// Alias for an array of bytes that represents an address.
 pub type Address = [u8; ADDRESS_LENGTH];
-
-/// Type alias for the system contract registry.
-pub type SystemContractRegistry = BTreeMap<String, ContractHash>;
-
-/// Type alias for the chainspec registry.
-pub type ChainspecRegistry = BTreeMap<String, Digest>;
-
-/// The entry in the `ChainspecRegistry` under which we store the hash of the chainspec.toml.
-pub const CHAINSPEC_RAW: &str = "chainspec_raw";
-/// The entry in the `ChainspecRegistry` under which we store the hash of the genesis_accounts.toml.
-pub const GENESIS_ACCOUNTS_RAW: &str = "genesis_accounts_raw";
-/// The entry in the `ChainspecRegistry` under which we store the hash of the global_state.toml.
-pub const GLOBAL_STATE_RAW: &str = "global_state_raw";

--- a/execution_engine/src/core/engine_state/chainspec_registry.rs
+++ b/execution_engine/src/core/engine_state/chainspec_registry.rs
@@ -1,0 +1,154 @@
+//! The registry of chainspec hash digests.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use casper_hashing::Digest;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    CLType, CLTyped,
+};
+
+type BytesreprChainspecRegistry = BTreeMap<String, Digest>;
+
+/// The chainspec registry.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct ChainspecRegistry {
+    chainspec_raw_hash: Digest,
+    genesis_accounts_raw_hash: Option<Digest>,
+    global_state_raw_hash: Option<Digest>,
+}
+
+impl ChainspecRegistry {
+    const CHAINSPEC_RAW_MAP_KEY: &'static str = "chainspec_raw";
+    const GENESIS_ACCOUNTS_RAW_MAP_KEY: &'static str = "genesis_accounts_raw";
+    const GLOBAL_STATE_RAW_MAP_KEY: &'static str = "global_state_raw";
+
+    /// Returns a `ChainspecRegistry` constructed at genesis.
+    pub fn new_with_genesis(
+        chainspec_file_bytes: &[u8],
+        genesis_accounts_file_bytes: &[u8],
+    ) -> Self {
+        ChainspecRegistry {
+            chainspec_raw_hash: Digest::hash(chainspec_file_bytes),
+            genesis_accounts_raw_hash: Some(Digest::hash(genesis_accounts_file_bytes)),
+            global_state_raw_hash: None,
+        }
+    }
+
+    /// Returns a `ChainspecRegistry` constructed at node upgrade.
+    pub fn new_with_optional_global_state(
+        chainspec_file_bytes: &[u8],
+        global_state_file_bytes: Option<&[u8]>,
+    ) -> Self {
+        ChainspecRegistry {
+            chainspec_raw_hash: Digest::hash(chainspec_file_bytes),
+            genesis_accounts_raw_hash: None,
+            global_state_raw_hash: global_state_file_bytes.map(Digest::hash),
+        }
+    }
+
+    /// Returns the hash of the raw bytes of the chainspec.toml file.
+    pub fn chainspec_raw_hash(&self) -> &Digest {
+        &self.chainspec_raw_hash
+    }
+
+    /// Returns the hash of the raw bytes of the genesis accounts.toml file if it exists.
+    pub fn genesis_accounts_raw_hash(&self) -> Option<&Digest> {
+        self.genesis_accounts_raw_hash.as_ref()
+    }
+
+    /// Returns the hash of the raw bytes of the global_state.toml file if it exists.
+    pub fn global_state_raw_hash(&self) -> Option<&Digest> {
+        self.global_state_raw_hash.as_ref()
+    }
+
+    fn as_map(&self) -> BytesreprChainspecRegistry {
+        let mut map = BTreeMap::new();
+        map.insert(
+            Self::CHAINSPEC_RAW_MAP_KEY.to_string(),
+            self.chainspec_raw_hash,
+        );
+        if let Some(genesis_accounts_raw_hash) = self.genesis_accounts_raw_hash {
+            map.insert(
+                Self::GENESIS_ACCOUNTS_RAW_MAP_KEY.to_string(),
+                genesis_accounts_raw_hash,
+            );
+        }
+        if let Some(global_state_raw_hash) = self.global_state_raw_hash {
+            map.insert(
+                Self::GLOBAL_STATE_RAW_MAP_KEY.to_string(),
+                global_state_raw_hash,
+            );
+        }
+        map
+    }
+
+    fn from_map(map: BytesreprChainspecRegistry) -> Result<Self, bytesrepr::Error> {
+        let chainspec_raw_hash = *map
+            .get(Self::CHAINSPEC_RAW_MAP_KEY)
+            .ok_or(bytesrepr::Error::Formatting)?;
+        let genesis_accounts_raw_hash = map.get(Self::GENESIS_ACCOUNTS_RAW_MAP_KEY).copied();
+        let global_state_raw_hash = map.get(Self::GLOBAL_STATE_RAW_MAP_KEY).copied();
+        Ok(ChainspecRegistry {
+            chainspec_raw_hash,
+            genesis_accounts_raw_hash,
+            global_state_raw_hash,
+        })
+    }
+}
+
+impl ToBytes for ChainspecRegistry {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.as_map().to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.as_map().serialized_length()
+    }
+}
+
+impl FromBytes for ChainspecRegistry {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (map, remainder) = BytesreprChainspecRegistry::from_bytes(bytes)?;
+        let chainspec_registry = ChainspecRegistry::from_map(map)?;
+        Ok((chainspec_registry, remainder))
+    }
+}
+
+impl CLTyped for ChainspecRegistry {
+    fn cl_type() -> CLType {
+        BytesreprChainspecRegistry::cl_type()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let mut rng = rand::thread_rng();
+
+        let chainspec_file_bytes: [u8; 10] = rng.gen();
+
+        let genesis_account_file_bytes: [u8; 10] = rng.gen();
+        let chainspec_registry =
+            ChainspecRegistry::new_with_genesis(&chainspec_file_bytes, &genesis_account_file_bytes);
+        bytesrepr::test_serialization_roundtrip(&chainspec_registry);
+
+        let global_state_file_bytes: [u8; 10] = rng.gen();
+        let chainspec_registry = ChainspecRegistry::new_with_optional_global_state(
+            &chainspec_file_bytes,
+            Some(&global_state_file_bytes),
+        );
+        bytesrepr::test_serialization_roundtrip(&chainspec_registry);
+
+        let chainspec_registry =
+            ChainspecRegistry::new_with_optional_global_state(&chainspec_file_bytes, None);
+        bytesrepr::test_serialization_roundtrip(&chainspec_registry);
+    }
+}

--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -97,9 +97,6 @@ pub enum Error {
     /// Failed to retrieve the current EraId from the auction state.
     #[error("Failed to retrieve the era_id from the auction state")]
     FailedToRetrieveEraId,
-    /// The chainspec registry did not contain the hash for the chainspec.
-    #[error("Missing chainspec.toml hash")]
-    MissingChainspecHash,
 }
 
 impl Error {

--- a/execution_engine/src/core/engine_state/executable_deploy_item.rs
+++ b/execution_engine/src/core/engine_state/executable_deploy_item.rs
@@ -18,6 +18,7 @@ use rand::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tracing::error;
 
 use casper_hashing::Digest;
 use casper_types::{
@@ -29,13 +30,11 @@ use casper_types::{
     EntryPoint, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs, StoredValue, U512,
 };
 
-use super::error;
 use crate::{
     core::{
-        engine_state::{Error, ExecError, MAX_PAYMENT_AMOUNT},
+        engine_state::{Error, ExecError, SystemContractRegistry, MAX_PAYMENT_AMOUNT},
         execution,
         tracking_copy::{TrackingCopy, TrackingCopyExt},
-        SystemContractRegistry,
     },
     shared::{newtypes::CorrelationId, wasm, wasm_prep, wasm_prep::Preprocessor},
     storage::global_state::StateReader,
@@ -379,7 +378,7 @@ impl ExecutableDeployItem {
 
         match self {
             ExecutableDeployItem::Transfer { .. } => {
-                return Err(error::Error::InvalidDeployItemVariant("Transfer".into()))
+                return Err(Error::InvalidDeployItemVariant("Transfer".into()))
             }
             ExecutableDeployItem::ModuleBytes { module_bytes, .. }
                 if module_bytes.is_empty() && phase == Phase::Payment =>
@@ -432,7 +431,7 @@ impl ExecutableDeployItem {
                         expected: protocol_version.value().major,
                         actual: contract.protocol_version().value().major,
                     };
-                    return Err(error::Error::Exec(exec_error));
+                    return Err(Error::Exec(exec_error));
                 }
 
                 contract_package = tracking_copy
@@ -442,7 +441,7 @@ impl ExecutableDeployItem {
             ExecutableDeployItem::StoredContractByName { name, .. } => {
                 // `ContractHash` is stored in named keys.
                 base_key = account.named_keys().get(name).cloned().ok_or_else(|| {
-                    error::Error::Exec(execution::Error::NamedKeyNotFound(name.to_string()))
+                    Error::Exec(execution::Error::NamedKeyNotFound(name.to_string()))
                 })?;
 
                 contract_hash =
@@ -457,7 +456,7 @@ impl ExecutableDeployItem {
                         expected: protocol_version.value().major,
                         actual: contract.protocol_version().value().major,
                     };
-                    return Err(error::Error::Exec(exec_error));
+                    return Err(Error::Exec(exec_error));
                 }
 
                 contract_package = tracking_copy
@@ -472,7 +471,7 @@ impl ExecutableDeployItem {
                         .get(name)
                         .cloned()
                         .ok_or_else(|| {
-                            error::Error::Exec(execution::Error::NamedKeyNotFound(name.to_string()))
+                            Error::Exec(execution::Error::NamedKeyNotFound(name.to_string()))
                         })?
                         .into_hash()
                         .ok_or(Error::InvalidKeyVariant)?
@@ -488,21 +487,21 @@ impl ExecutableDeployItem {
 
                 let contract_version_key = maybe_version_key
                     .or_else(|| contract_package.current_contract_version())
-                    .ok_or(error::Error::Exec(
-                        execution::Error::NoActiveContractVersions(contract_package_hash),
-                    ))?;
+                    .ok_or(Error::Exec(execution::Error::NoActiveContractVersions(
+                        contract_package_hash,
+                    )))?;
 
                 if !contract_package.is_version_enabled(contract_version_key) {
-                    return Err(error::Error::Exec(
-                        execution::Error::InvalidContractVersion(contract_version_key),
-                    ));
+                    return Err(Error::Exec(execution::Error::InvalidContractVersion(
+                        contract_version_key,
+                    )));
                 }
 
                 let looked_up_contract_hash: ContractHash = contract_package
                     .lookup_contract_hash(contract_version_key)
-                    .ok_or(error::Error::Exec(
-                        execution::Error::InvalidContractVersion(contract_version_key),
-                    ))?
+                    .ok_or(Error::Exec(execution::Error::InvalidContractVersion(
+                        contract_version_key,
+                    )))?
                     .to_owned();
 
                 contract = tracking_copy
@@ -527,22 +526,22 @@ impl ExecutableDeployItem {
                 let contract_version_key = maybe_version_key
                     .or_else(|| contract_package.current_contract_version())
                     .ok_or({
-                        error::Error::Exec(execution::Error::NoActiveContractVersions(
+                        Error::Exec(execution::Error::NoActiveContractVersions(
                             *contract_package_hash,
                         ))
                     })?;
 
                 if !contract_package.is_version_enabled(contract_version_key) {
-                    return Err(error::Error::Exec(
-                        execution::Error::InvalidContractVersion(contract_version_key),
-                    ));
+                    return Err(Error::Exec(execution::Error::InvalidContractVersion(
+                        contract_version_key,
+                    )));
                 }
 
                 let looked_up_contract_hash = *contract_package
                     .lookup_contract_hash(contract_version_key)
-                    .ok_or(error::Error::Exec(
-                        execution::Error::InvalidContractVersion(contract_version_key),
-                    ))?;
+                    .ok_or(Error::Exec(execution::Error::InvalidContractVersion(
+                        contract_version_key,
+                    )))?;
                 contract = tracking_copy
                     .borrow_mut()
                     .get_contract(correlation_id, looked_up_contract_hash)?;
@@ -558,13 +557,10 @@ impl ExecutableDeployItem {
             .entry_point(entry_point_name)
             .cloned()
             .ok_or_else(|| {
-                error::Error::Exec(execution::Error::NoSuchMethod(entry_point_name.to_owned()))
+                Error::Exec(execution::Error::NoSuchMethod(entry_point_name.to_owned()))
             })?;
 
-        if system_contract_registry
-            .values()
-            .any(|value| *value == contract_hash)
-        {
+        if system_contract_registry.has_contract_hash(&contract_hash) {
             let module = wasm::do_nothing_module(preprocessor)?;
             return Ok(DeployMetadata {
                 kind: DeployKind::System,

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -40,12 +40,14 @@ use casper_types::{
 
 use crate::{
     core::{
-        engine_state::{execution_effect::ExecutionEffect, EngineConfig},
+        engine_state::{
+            execution_effect::ExecutionEffect, ChainspecRegistry, EngineConfig,
+            SystemContractRegistry,
+        },
         execution,
         execution::{AddressGenerator, Executor},
         runtime::RuntimeStack,
         tracking_copy::{TrackingCopy, TrackingCopyExt},
-        ChainspecRegistry, SystemContractRegistry, CHAINSPEC_RAW, GENESIS_ACCOUNTS_RAW,
     },
     shared::{newtypes::CorrelationId, system_config::SystemConfig, wasm_config::WasmConfig},
     storage::global_state::StateProvider,
@@ -728,7 +730,7 @@ pub enum GenesisError {
         validator_slots: u32,
     },
     /// The chainspec registry is missing a required entry.
-    MissingChainspecRegistryEntry(String),
+    MissingChainspecRegistryEntry,
 }
 
 pub(crate) struct GenesisInstaller<S>
@@ -1372,16 +1374,8 @@ where
         &self,
         chainspec_registry: ChainspecRegistry,
     ) -> Result<(), GenesisError> {
-        if chainspec_registry.get(CHAINSPEC_RAW).is_none() {
-            return Err(GenesisError::MissingChainspecRegistryEntry(
-                CHAINSPEC_RAW.to_string(),
-            ));
-        }
-
-        if chainspec_registry.get(GENESIS_ACCOUNTS_RAW).is_none() {
-            return Err(GenesisError::MissingChainspecRegistryEntry(
-                GENESIS_ACCOUNTS_RAW.to_string(),
-            ));
+        if chainspec_registry.genesis_accounts_raw_hash().is_none() {
+            return Err(GenesisError::MissingChainspecRegistryEntry);
         }
         let cl_value_registry = CLValue::from_t(chainspec_registry)
             .map_err(|error| GenesisError::CLValue(error.to_string()))?;

--- a/execution_engine/src/core/engine_state/run_genesis_request.rs
+++ b/execution_engine/src/core/engine_state/run_genesis_request.rs
@@ -6,11 +6,10 @@ use rand::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ChainspecRegistry, CHAINSPEC_RAW};
 use casper_hashing::Digest;
 use casper_types::ProtocolVersion;
 
-use super::genesis::ExecConfig;
+use super::{genesis::ExecConfig, ChainspecRegistry};
 
 /// Represents a genesis request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,14 +68,11 @@ impl Distribution<RunGenesisRequest> for Standard {
         let genesis_config_hash = Digest::hash(&input);
         let protocol_version = ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen());
         let ee_config = rng.gen();
-        let chainspec_registry = {
-            let mut chainspec_registry = ChainspecRegistry::new();
-            chainspec_registry.insert(
-                CHAINSPEC_RAW.to_string(),
-                Digest::hash(rng.gen::<[u8; 32]>()),
-            );
-            chainspec_registry
-        };
+
+        let chainspec_file_bytes: [u8; 10] = rng.gen();
+        let genesis_account_file_bytes: [u8; 15] = rng.gen();
+        let chainspec_registry =
+            ChainspecRegistry::new_with_genesis(&chainspec_file_bytes, &genesis_account_file_bytes);
         RunGenesisRequest::new(
             genesis_config_hash,
             protocol_version,

--- a/execution_engine/src/core/engine_state/system_contract_registry.rs
+++ b/execution_engine/src/core/engine_state/system_contract_registry.rs
@@ -1,0 +1,74 @@
+//! The registry of system contracts.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    CLType, CLTyped, ContractHash,
+};
+
+/// The system contract registry.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct SystemContractRegistry(BTreeMap<String, ContractHash>);
+
+impl SystemContractRegistry {
+    /// Returns a new `SystemContractRegistry`.
+    #[allow(clippy::new_without_default)] // This empty `new()` will be replaced in the future.
+    pub fn new() -> Self {
+        SystemContractRegistry(BTreeMap::new())
+    }
+
+    /// Inserts a contract's details into the registry.
+    pub fn insert(&mut self, contract_name: String, contract_hash: ContractHash) {
+        self.0.insert(contract_name, contract_hash);
+    }
+
+    /// Gets a contract's hash from the registry.
+    pub fn get(&self, contract_name: &str) -> Option<&ContractHash> {
+        self.0.get(contract_name)
+    }
+
+    /// Returns `true` if the given contract hash exists as a value in the registry.
+    pub fn has_contract_hash(&self, contract_hash: &ContractHash) -> bool {
+        self.0
+            .values()
+            .any(|system_contract_hash| system_contract_hash == contract_hash)
+    }
+}
+
+impl ToBytes for SystemContractRegistry {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}
+
+impl FromBytes for SystemContractRegistry {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (inner, remainder) = BTreeMap::from_bytes(bytes)?;
+        Ok((SystemContractRegistry(inner), remainder))
+    }
+}
+
+impl CLTyped for SystemContractRegistry {
+    fn cl_type() -> CLType {
+        BTreeMap::<String, ContractHash>::cl_type()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let mut system_contract_registry = SystemContractRegistry::new();
+        system_contract_registry.insert("a".to_string(), ContractHash::new([9; 32]));
+        bytesrepr::test_serialization_roundtrip(&system_contract_registry);
+    }
+}

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -12,8 +12,8 @@ use casper_types::{
 
 use crate::{
     core::{
-        engine_state::execution_effect::ExecutionEffect, tracking_copy::TrackingCopy,
-        ChainspecRegistry,
+        engine_state::{execution_effect::ExecutionEffect, ChainspecRegistry},
+        tracking_copy::TrackingCopy,
     },
     shared::newtypes::CorrelationId,
     storage::global_state::StateProvider,
@@ -143,11 +143,6 @@ impl UpgradeConfig {
     /// Sets new pre state hash.
     pub fn with_pre_state_hash(&mut self, pre_state_hash: Digest) {
         self.pre_state_hash = pre_state_hash;
-    }
-
-    /// Sets the chainspec registry to the upgrade config.
-    pub fn with_chainspec_registry(&mut self, chainspec_registry: ChainspecRegistry) {
-        self.chainspec_registry = chainspec_registry
     }
 }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -2075,8 +2075,7 @@ where
         if !self
             .context
             .system_contract_registry()?
-            .values()
-            .any(|&system_hash| system_hash == contract_hash)
+            .has_contract_hash(&contract_hash)
         {
             let entry_point_args_lookup: BTreeMap<&str, &Parameter> = entry_point
                 .args()

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -25,11 +25,11 @@ use casper_types::{
 
 use crate::{
     core::{
-        engine_state::{execution_effect::ExecutionEffect, EngineConfig},
+        engine_state::{execution_effect::ExecutionEffect, EngineConfig, SystemContractRegistry},
         execution::{AddressGenerator, Error},
         runtime_context::dictionary::DictionaryValue,
         tracking_copy::{AddResult, TrackingCopy, TrackingCopyExt},
-        Address, SystemContractRegistry,
+        Address,
     },
     shared::{execution_journal::ExecutionJournal, newtypes::CorrelationId},
     storage::global_state::StateReader,
@@ -814,8 +814,7 @@ where
     pub(crate) fn is_system_contract(&self, contract_hash: &ContractHash) -> Result<bool, Error> {
         Ok(self
             .system_contract_registry()?
-            .values()
-            .any(|system_hash| system_hash == contract_hash))
+            .has_contract_hash(contract_hash))
     }
 
     /// Charges gas for specified amount of bytes used.

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -24,9 +24,10 @@ use casper_types::{
 use super::{Address, Error, RuntimeContext};
 use crate::{
     core::{
-        engine_state::EngineConfig, execution::AddressGenerator,
-        runtime::extract_access_rights_from_keys, tracking_copy::TrackingCopy,
-        SystemContractRegistry,
+        engine_state::{EngineConfig, SystemContractRegistry},
+        execution::AddressGenerator,
+        runtime::extract_access_rights_from_keys,
+        tracking_copy::TrackingCopy,
     },
     shared::{additive_map::AdditiveMap, newtypes::CorrelationId, transform::Transform},
     storage::global_state::{

--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -9,7 +9,7 @@ use casper_types::{
 };
 
 use crate::{
-    core::{execution, tracking_copy::TrackingCopy, SystemContractRegistry},
+    core::{engine_state::SystemContractRegistry, execution, tracking_copy::TrackingCopy},
     shared::{newtypes::CorrelationId, wasm, wasm_prep::Preprocessor},
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -19,12 +19,8 @@ use num_rational::Ratio;
 use once_cell::sync::Lazy;
 
 use casper_execution_engine::{
-    core::{
-        engine_state::{
-            genesis::{ExecConfig, GenesisAccount, GenesisConfig},
-            run_genesis_request::RunGenesisRequest,
-        },
-        ChainspecRegistry, CHAINSPEC_RAW, GENESIS_ACCOUNTS_RAW,
+    core::engine_state::{
+        ChainspecRegistry, ExecConfig, GenesisAccount, GenesisConfig, RunGenesisRequest,
     },
     shared::{system_config::SystemConfig, wasm_config::WasmConfig},
 };
@@ -146,15 +142,8 @@ pub static DEFAULT_GENESIS_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {
     )
 });
 /// Default [`ChainspecRegistry`].
-pub static DEFAULT_CHAINSPEC_REGISTRY: Lazy<ChainspecRegistry> = Lazy::new(|| {
-    let mut chainspec_registry = ChainspecRegistry::new();
-    chainspec_registry.insert(CHAINSPEC_RAW.to_string(), *DEFAULT_GENESIS_CONFIG_HASH);
-    chainspec_registry.insert(
-        GENESIS_ACCOUNTS_RAW.to_string(),
-        *DEFAULT_GENESIS_CONFIG_HASH,
-    );
-    chainspec_registry
-});
+pub static DEFAULT_CHAINSPEC_REGISTRY: Lazy<ChainspecRegistry> =
+    Lazy::new(|| ChainspecRegistry::new_with_genesis(&[1, 2, 3], &[4, 5, 6]));
 /// Default [`RunGenesisRequest`].
 pub static DEFAULT_RUN_GENESIS_REQUEST: Lazy<RunGenesisRequest> = Lazy::new(|| {
     RunGenesisRequest::new(

--- a/execution_engine_testing/test_support/src/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/upgrade_request_builder.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 
 use num_rational::Ratio;
 
-use casper_execution_engine::core::{
-    engine_state::UpgradeConfig, ChainspecRegistry, CHAINSPEC_RAW,
-};
+use casper_execution_engine::core::engine_state::{ChainspecRegistry, UpgradeConfig};
 use casper_hashing::Digest;
 use casper_types::{EraId, Key, ProtocolVersion, StoredValue};
 
@@ -121,11 +119,6 @@ impl UpgradeRequestBuilder {
 
 impl Default for UpgradeRequestBuilder {
     fn default() -> Self {
-        let chainspec_registry = {
-            let mut registry = ChainspecRegistry::new();
-            registry.insert(CHAINSPEC_RAW.to_string(), Digest::default());
-            registry
-        };
         UpgradeRequestBuilder {
             pre_state_hash: Default::default(),
             current_protocol_version: Default::default(),
@@ -137,7 +130,7 @@ impl Default for UpgradeRequestBuilder {
             new_round_seigniorage_rate: None,
             new_unbonding_delay: None,
             global_state_update: Default::default(),
-            chainspec_registry,
+            chainspec_registry: ChainspecRegistry::new_with_optional_global_state(&[], None),
         }
     }
 }

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -15,17 +15,13 @@ use log::LevelFilter;
 use bytesrepr::FromBytes;
 use casper_execution_engine::{
     core::{
-        engine_state,
         engine_state::{
-            era_validators::GetEraValidatorsRequest,
-            execute_request::ExecuteRequest,
-            execution_result::ExecutionResult,
-            run_genesis_request::RunGenesisRequest,
-            step::{StepRequest, StepSuccess},
-            BalanceResult, EngineConfig, EngineState, GenesisSuccess, GetBidsRequest, QueryRequest,
-            QueryResult, StepError, UpgradeConfig, UpgradeSuccess,
+            self, BalanceResult, EngineConfig, EngineState, ExecuteRequest, ExecutionResult,
+            GenesisSuccess, GetBidsRequest, GetEraValidatorsRequest, QueryRequest, QueryResult,
+            RunGenesisRequest, StepError, StepRequest, StepSuccess, SystemContractRegistry,
+            UpgradeConfig, UpgradeSuccess,
         },
-        execution, SystemContractRegistry,
+        execution,
     },
     shared::{
         additive_map::AdditiveMap,

--- a/execution_engine_testing/tests/src/test/regression/gh_1470.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1470.rs
@@ -5,7 +5,10 @@ use casper_engine_test_support::{
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_RUN_GENESIS_REQUEST,
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::core::{engine_state::Error, execution, SystemContractRegistry};
+use casper_execution_engine::core::{
+    engine_state::{Error, SystemContractRegistry},
+    execution,
+};
 use casper_hashing::Digest;
 use casper_types::{
     account::AccountHash,

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -26,8 +26,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add `verifiable_chunked_hash_activation` to the chainspec to specify the first era in which the new Merkle tree-based hashing scheme is used.
 * In addition to `consensus` and `deploy_requests`, the following values can now be controlled via the `[network.estimator_weights]` section in config: `gossip`, `finality_signatures`, `deploy_responses`, `block_requests`, `block_responses`, `trie_requests` and `trie_responses`.
 * Nodes will now also gossip deploys onwards while joining.
-  Added run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
-* Added a new RPC and REST endpoint that returns the bytes of the `chainspec.toml` file.
+* Add run-mode field to the `/status` endpoint and the `info_get_status` JSON-RPC.
+* Add new REST `/chainspec` and JSON-RPC `info_get_chainspec` endpoints that return the raw bytes of the `chainspec.toml`, `accounts.toml` and `global_state.toml` files as read at node startup.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     crypto::AsymmetricKeyExt,
     reactor::{EventQueueHandle, QueueKind, Scheduler},
     testing::TestRng,
-    types::{BlockPayload, TimeDiff},
+    types::{BlockPayload, ChainspecRawBytes, TimeDiff},
     utils::{self, Loadable},
 };
 
@@ -167,8 +167,8 @@ async fn validate_block(
     // Create the reactor and component.
     let reactor = MockReactor::new();
     let effect_builder = EffectBuilder::new(EventQueueHandle::without_shutdown(reactor.scheduler));
-    let chainspec = Arc::new(Chainspec::from_resources("local"));
-    let mut block_validator = BlockValidator::new(chainspec);
+    let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
+    let mut block_validator = BlockValidator::new(Arc::new(chainspec));
 
     // Pass the block to the component. This future will eventually resolve to the result, i.e.
     // whether the block is valid or not.

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -1,15 +1,16 @@
 use std::{sync::Arc, time::Duration};
 
-use casper_execution_engine::core::ChainspecRegistry;
 use datasize::DataSize;
 use num::rational::Ratio;
 
-use casper_execution_engine::core::engine_state::UpgradeConfig;
+use casper_execution_engine::core::engine_state::{ChainspecRegistry, UpgradeConfig};
 use casper_types::{bytesrepr, EraId, ProtocolVersion};
 
 use crate::{
     components::consensus::ChainspecConsensusExt,
-    types::{BlockHash, BlockHeader, Chainspec, NodeConfig, TimeDiff, Timestamp},
+    types::{
+        BlockHash, BlockHeader, Chainspec, ChainspecRawBytes, NodeConfig, TimeDiff, Timestamp,
+    },
     SmallNetworkConfig,
 };
 
@@ -153,8 +154,13 @@ impl Config {
     pub(super) fn new_upgrade_config(
         &self,
         upgrade_block_header: &BlockHeader,
+        chainspec_raw_bytes: Arc<ChainspecRawBytes>,
     ) -> Result<Box<UpgradeConfig>, bytesrepr::Error> {
         let global_state_update = self.chainspec.protocol_config.get_update_mapping()?;
+        let chainspec_registry = ChainspecRegistry::new_with_optional_global_state(
+            chainspec_raw_bytes.chainspec_bytes(),
+            chainspec_raw_bytes.maybe_global_state_bytes(),
+        );
         let upgrade_config = UpgradeConfig::new(
             *upgrade_block_header.state_root_hash(),
             upgrade_block_header.protocol_version(),
@@ -166,7 +172,7 @@ impl Config {
             Some(self.chainspec.core_config.round_seigniorage_rate),
             Some(self.chainspec.core_config.unbonding_delay),
             global_state_update,
-            ChainspecRegistry::new(),
+            chainspec_registry,
         );
         Ok(Box::new(upgrade_config))
     }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -1165,7 +1165,7 @@ mod tests {
         components::consensus::EraReport,
         crypto::AsymmetricKeyExt,
         testing::TestRng,
-        types::{Block, BlockPayload, Chainspec, FinalizedBlock, NodeConfig},
+        types::{Block, BlockPayload, Chainspec, ChainspecRawBytes, FinalizedBlock, NodeConfig},
         utils::Loadable,
         SmallNetworkConfig,
     };
@@ -1223,7 +1223,7 @@ mod tests {
     #[test]
     fn test_is_current_era() {
         let mut rng = TestRng::new();
-        let mut chainspec = Chainspec::from_resources("local");
+        let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
 
         let genesis_time = chainspec
             .protocol_config

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -9,7 +9,7 @@ use crate::{
     tls::{KeyFingerprint, Sha512},
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        ActivationPoint, Chainspec, NodeId, Timestamp,
+        ActivationPoint, Chainspec, ChainspecRawBytes, NodeId, Timestamp,
     },
     utils::Loadable,
 };
@@ -35,7 +35,7 @@ where
     I: IntoIterator<Item = (PublicKey, T)>,
     T: Into<U512>,
 {
-    let mut chainspec = Chainspec::from_resources("local");
+    let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
     let accounts = stakes
         .into_iter()
         .map(|(pk, stake)| {

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -37,7 +37,7 @@ use crate::{
     protocol::Message,
     reactor::{self, EventQueueHandle, QueueKind, Runner},
     testing::ConditionCheckReactor,
-    types::{Block, Chainspec, Deploy, NodeId},
+    types::{Block, Chainspec, ChainspecRawBytes, Deploy, NodeId},
     utils::{Loadable, WithDir},
     NodeRng,
 };
@@ -403,7 +403,7 @@ impl reactor::Reactor for Reactor {
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
 
-        let chainspec = Chainspec::from_resources("local");
+        let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
 
         let deploy_acceptor =
             DeployAcceptor::new(super::Config::new(VERIFY_ACCOUNTS), &chainspec, registry).unwrap();
@@ -687,7 +687,7 @@ async fn run_deploy_acceptor_without_timeout(
     let mut runner: Runner<ConditionCheckReactor<Reactor>> =
         Runner::new(test_scenario, &mut rng).await.unwrap();
 
-    let chainspec = Chainspec::from_resources("local");
+    let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
 
     let block = Box::new(Block::random_with_verifiable_chunked_hash_activation(
         &mut rng,

--- a/node/src/components/rest_server/filters.rs
+++ b/node/src/components/rest_server/filters.rs
@@ -128,7 +128,7 @@ pub(super) fn create_chainspec_filter<REv: ReactorEventT>(
             effect_builder
                 .get_chainspec_raw_bytes()
                 .map(move |chainspec_bytes| {
-                    let result = GetChainspecResult::new(api_version, chainspec_bytes);
+                    let result = GetChainspecResult::new(api_version, (*chainspec_bytes).clone());
                     Ok::<_, Rejection>(reply::json(&result).into_response())
                 })
         })

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -110,9 +110,9 @@ pub(super) async fn run<REv: ReactorEventT>(
         .or(rpc_get_rpcs)
         .or(rpc_get_dictionary_item)
         .or(rpc_get_trie)
+        .or(rpc_get_chainspec)
         .or(rpc_query_global_state)
         .or(unknown_method)
-        .or(rpc_get_chainspec)
         .or(parse_failure);
 
     // Supports content negotiation for gzip responses. This is an interim fix until

--- a/node/src/components/rpc_server/rpcs/info.rs
+++ b/node/src/components/rpc_server/rpcs/info.rs
@@ -22,11 +22,11 @@ use super::{
     RpcWithoutParamsExt,
 };
 use crate::{
-    components::{chainspec_loader::ChainspecRawBytes, consensus::ValidatorChange},
+    components::consensus::ValidatorChange,
     crypto::AsymmetricKeyExt,
     effect::EffectBuilder,
     reactor::QueueKind,
-    types::{Block, BlockHash, Deploy, DeployHash, GetStatusResult, PeersMap},
+    types::{Block, BlockHash, ChainspecRawBytes, Deploy, DeployHash, GetStatusResult, PeersMap},
 };
 
 static GET_DEPLOY_PARAMS: Lazy<GetDeployParams> = Lazy::new(|| GetDeployParams {
@@ -55,7 +55,7 @@ static GET_VALIDATOR_CHANGES_RESULT: Lazy<GetValidatorChangesResult> = Lazy::new
 });
 static GET_CHAINSPEC_RESULT: Lazy<GetChainspecResult> = Lazy::new(|| GetChainspecResult {
     api_version: DOCS_EXAMPLE_PROTOCOL_VERSION,
-    chainspec_bytes: ChainspecRawBytes::new(vec![42, 42], None, None),
+    chainspec_bytes: ChainspecRawBytes::new(vec![42, 42].into(), None, None),
 });
 
 /// Params for "info_get_deploy" RPC request.
@@ -388,7 +388,7 @@ impl RpcWithoutParamsExt for GetChainspec {
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             let chainspec_bytes = effect_builder.get_chainspec_raw_bytes().await;
-            let result = Self::ResponseResult::new(api_version, chainspec_bytes);
+            let result = Self::ResponseResult::new(api_version, (*chainspec_bytes).clone());
             Ok(response_builder.success(result)?)
         }
         .boxed()

--- a/node/src/data_migration.rs
+++ b/node/src/data_migration.rs
@@ -11,7 +11,7 @@ use casper_types::{ProtocolVersion, PublicKey, SecretKey, Signature};
 use crate::{
     crypto,
     reactor::participating::Config,
-    types::{chainspec, Chainspec},
+    types::{chainspec, Chainspec, ChainspecRawBytes},
     utils::{LoadError, Loadable, WithDir},
 };
 
@@ -200,8 +200,9 @@ pub(crate) fn migrate_data(
     new_config: WithDir<Config>,
 ) -> Result<(), Error> {
     let (new_root, new_config) = new_config.into_parts();
-    let new_protocol_version = Chainspec::from_path(&new_root)
+    let new_protocol_version = <(Chainspec, ChainspecRawBytes)>::from_path(&new_root)
         .map_err(Error::LoadChainspec)?
+        .0
         .protocol_config
         .version;
     let secret_key: Arc<SecretKey> = new_config

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -100,7 +100,7 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
-        chainspec_loader::{ChainspecRawBytes, CurrentRunInfo, NextUpgrade},
+        chainspec_loader::{CurrentRunInfo, NextUpgrade},
         consensus::{BlockContext, ClContext, EraDump, ValidatorChange},
         contract_runtime::{
             BlockAndExecutionEffects, BlockExecutionError, EraValidatorsRequest, ExecutionPreState,
@@ -112,8 +112,9 @@ use crate::{
     reactor::{EventQueueHandle, QueueKind},
     types::{
         Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockPayload, BlockSignatures,
-        BlockWithMetadata, Chainspec, ChainspecInfo, Deploy, DeployHash, DeployHeader,
-        DeployMetadata, FinalitySignature, FinalizedBlock, Item, NodeId, TimeDiff, Timestamp,
+        BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash,
+        DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item, NodeId, TimeDiff,
+        Timestamp,
     },
     utils::{SharedFlag, Source},
 };
@@ -1464,6 +1465,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn commit_genesis(
         self,
         chainspec: Arc<Chainspec>,
+        chainspec_raw_bytes: Arc<ChainspecRawBytes>,
     ) -> Result<GenesisSuccess, engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
@@ -1471,6 +1473,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| ContractRuntimeRequest::CommitGenesis {
                 chainspec,
+                chainspec_raw_bytes,
                 responder,
             },
             QueueKind::Regular,
@@ -1844,7 +1847,7 @@ impl<REv> EffectBuilder<REv> {
 
     /// Get the bytes for the chainspec file and genesis_accounts
     /// and global_state bytes if the files are present.
-    pub(crate) async fn get_chainspec_raw_bytes(self) -> ChainspecRawBytes
+    pub(crate) async fn get_chainspec_raw_bytes(self) -> Arc<ChainspecRawBytes>
     where
         REv: From<ChainspecLoaderRequest> + Send,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -36,7 +36,7 @@ use casper_types::{
 use crate::{
     components::{
         block_validator::ValidatingBlock,
-        chainspec_loader::{ChainspecRawBytes, CurrentRunInfo},
+        chainspec_loader::CurrentRunInfo,
         consensus::{BlockContext, ClContext, ValidatorChange},
         contract_runtime::{
             BlockAndExecutionEffects, BlockExecutionError, EraValidatorsRequest, ExecutionPreState,
@@ -48,8 +48,8 @@ use crate::{
     rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
         Block, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockPayload, BlockSignatures,
-        BlockWithMetadata, Chainspec, ChainspecInfo, Deploy, DeployHash, DeployMetadata,
-        FinalizedBlock, Item, NodeId, StatusFeed, TimeDiff,
+        BlockWithMetadata, Chainspec, ChainspecInfo, ChainspecRawBytes, Deploy, DeployHash,
+        DeployMetadata, FinalizedBlock, Item, NodeId, StatusFeed, TimeDiff,
     },
     utils::{DisplayIter, Source},
 };
@@ -766,6 +766,8 @@ pub(crate) enum ContractRuntimeRequest {
     CommitGenesis {
         /// The chainspec.
         chainspec: Arc<Chainspec>,
+        /// The chainspec files' raw bytes.
+        chainspec_raw_bytes: Arc<ChainspecRawBytes>,
         /// Responder to call with the result.
         responder: Responder<Result<GenesisSuccess, engine_state::Error>>,
     },
@@ -1020,10 +1022,9 @@ pub(crate) enum ChainspecLoaderRequest {
     GetChainspecInfo(Responder<ChainspecInfo>),
     /// Request for information about the current run.
     GetCurrentRunInfo(Responder<CurrentRunInfo>),
-    /// Request for the chainspec file bytes
-    /// with the genesis_accounts and global_state bytes,
-    /// if they are present.
-    GetChainspecRawBytes(Responder<ChainspecRawBytes>),
+    /// Request for the chainspec file bytes with the genesis_accounts and global_state bytes, if
+    /// they are present.
+    GetChainspecRawBytes(Responder<Arc<ChainspecRawBytes>>),
 }
 
 impl Display for ChainspecLoaderRequest {

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -362,7 +362,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         testing::network::NetworkedReactor,
-        types::{Chainspec, NodeId},
+        types::{Chainspec, ChainspecRawBytes, NodeId},
     };
     use std::sync::Arc;
 
@@ -372,10 +372,11 @@ pub(crate) mod tests {
             registry: &Registry,
             event_queue: EventQueueHandle<Event>,
             chainspec: Arc<Chainspec>,
+            chainspec_raw_bytes: Arc<ChainspecRawBytes>,
         ) -> Result<(Self, Effects<Event>), Error> {
             let effect_builder = EffectBuilder::new(event_queue);
             let (chainspec_loader, chainspec_effects) =
-                ChainspecLoader::new_with_chainspec(chainspec, effect_builder);
+                ChainspecLoader::new_with_chainspec(chainspec, chainspec_raw_bytes, effect_builder);
             Self::new_with_chainspec_loader(config, registry, chainspec_loader, chainspec_effects)
         }
     }

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -25,7 +25,7 @@ use crate::{
         wrap_effects, EventQueueHandle, QueueKind, Reactor, ReactorEvent, ReactorExit, Scheduler,
     },
     testing::network::NetworkedReactor,
-    types::{Chainspec, NodeId},
+    types::{Chainspec, ChainspecRawBytes, NodeId},
     utils::{self, WithDir, RESOURCES_PATH},
     NodeRng,
 };
@@ -197,6 +197,7 @@ where
 pub(crate) struct InitializerReactorConfigWithChainspec {
     config: <InitializerReactor as Reactor>::Config,
     chainspec: Arc<Chainspec>,
+    chainspec_raw_bytes: Arc<ChainspecRawBytes>,
 }
 
 impl Reactor for MultiStageTestReactor {
@@ -224,6 +225,7 @@ impl Reactor for MultiStageTestReactor {
             registry,
             initializer_event_queue_handle,
             initializer_reactor_config_with_chainspec.chainspec,
+            initializer_reactor_config_with_chainspec.chainspec_raw_bytes,
         )
         .map_err(MultiStageTestReactorError::CouldNotMakeInitializerReactor)?;
 

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -26,8 +26,8 @@ pub use block::{
     HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
 };
 pub(crate) use block::{BlockHeaderWithMetadata, BlockPayload, BlockWithMetadata};
-pub(crate) use chainspec::ActivationPoint;
 pub use chainspec::Chainspec;
+pub(crate) use chainspec::{ActivationPoint, ChainspecRawBytes};
 pub use datasize::DataSize;
 pub use deploy::{
     Approval, Deploy, DeployConfigurationFailure, DeployHash, DeployHeader, DeployMetadata,

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -3,6 +3,7 @@
 
 mod accounts_config;
 mod activation_point;
+mod chainspec_raw_bytes;
 mod core_config;
 mod deploy_config;
 mod error;
@@ -34,22 +35,17 @@ use casper_types::{
 pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
 pub use self::error::Error;
 pub(crate) use self::{
-    accounts_config::AccountsConfig, activation_point::ActivationPoint, core_config::CoreConfig,
-    deploy_config::DeployConfig, global_state_update::GlobalStateUpdate,
-    highway_config::HighwayConfig, network_config::NetworkConfig, protocol_config::ProtocolConfig,
+    accounts_config::AccountsConfig, activation_point::ActivationPoint,
+    chainspec_raw_bytes::ChainspecRawBytes, core_config::CoreConfig, deploy_config::DeployConfig,
+    global_state_update::GlobalStateUpdate, highway_config::HighwayConfig,
+    network_config::NetworkConfig, protocol_config::ProtocolConfig,
 };
 #[cfg(test)]
 use crate::testing::TestRng;
 use crate::utils::Loadable;
 
 /// The name of the chainspec file on disk.
-pub const CHAINSPEC_NAME: &str = "chainspec.toml";
-
-/// The name of the genesis accounts file on disk.
-pub const GENESIS_ACCOUNTS_NAME: &str = "accounts.toml";
-
-/// The name of the global state toml file on disk.
-pub const GLOBAL_STATE_UPDATE: &str = "global_state.toml";
+pub const CHAINSPEC_FILENAME: &str = "chainspec.toml";
 
 /// A collection of configuration settings describing the state of the system at genesis and after
 /// upgrades to basic system functionality occurring after genesis.
@@ -182,11 +178,11 @@ impl FromBytes for Chainspec {
     }
 }
 
-impl Loadable for Chainspec {
+impl Loadable for (Chainspec, ChainspecRawBytes) {
     type Error = Error;
 
     fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error> {
-        parse_toml::parse_toml(path.as_ref().join(CHAINSPEC_NAME))
+        parse_toml::parse_toml(path.as_ref().join(CHAINSPEC_FILENAME))
     }
 }
 
@@ -387,9 +383,9 @@ mod tests {
     #[ignore = "We probably need to reconsider our approach here"]
     #[test]
     fn check_bundled_spec() {
-        let chainspec = Chainspec::from_resources("test/valid/0_9_0");
+        let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("test/valid/0_9_0");
         check_spec(chainspec, true);
-        let chainspec = Chainspec::from_resources("test/valid/1_0_0");
+        let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("test/valid/1_0_0");
         check_spec(chainspec, false);
     }
 
@@ -419,8 +415,9 @@ mod tests {
         // Different accounts.toml file content
         assert_ne!(accounts, accounts_unordered);
 
-        let chainspec = Chainspec::from_resources(PATH);
-        let chainspec_unordered = Chainspec::from_resources(PATH_UNORDERED);
+        let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources(PATH);
+        let (chainspec_unordered, _) =
+            <(Chainspec, ChainspecRawBytes)>::from_resources(PATH_UNORDERED);
 
         // Deserializes into equal objects
         assert_eq!(chainspec, chainspec_unordered);

--- a/node/src/types/chainspec/chainspec_raw_bytes.rs
+++ b/node/src/types/chainspec/chainspec_raw_bytes.rs
@@ -1,0 +1,57 @@
+use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use casper_types::bytesrepr::Bytes;
+
+/// The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.
+#[derive(Clone, Debug, Serialize, Deserialize, DataSize, JsonSchema)]
+pub struct ChainspecRawBytes {
+    #[schemars(
+        with = "String",
+        description = "Hex-encoded raw bytes of the current chainspec.toml file."
+    )]
+    chainspec_bytes: Bytes,
+    #[schemars(
+        with = "String",
+        description = "Hex-encoded raw bytes of the current genesis accounts.toml file."
+    )]
+    maybe_genesis_accounts_bytes: Option<Bytes>,
+    #[schemars(
+        with = "String",
+        description = "Hex-encoded raw bytes of the current global_state.toml file."
+    )]
+    maybe_global_state_bytes: Option<Bytes>,
+}
+
+impl ChainspecRawBytes {
+    pub(crate) fn new(
+        chainspec_bytes: Bytes,
+        maybe_genesis_accounts_bytes: Option<Bytes>,
+        maybe_global_state_bytes: Option<Bytes>,
+    ) -> Self {
+        ChainspecRawBytes {
+            chainspec_bytes,
+            maybe_genesis_accounts_bytes,
+            maybe_global_state_bytes,
+        }
+    }
+
+    pub(crate) fn chainspec_bytes(&self) -> &[u8] {
+        self.chainspec_bytes.as_slice()
+    }
+
+    pub(crate) fn maybe_genesis_accounts_bytes(&self) -> Option<&[u8]> {
+        match self.maybe_genesis_accounts_bytes.as_ref() {
+            Some(bytes) => Some(bytes.as_slice()),
+            None => None,
+        }
+    }
+
+    pub(crate) fn maybe_global_state_bytes(&self) -> Option<&[u8]> {
+        match self.maybe_global_state_bytes.as_ref() {
+            Some(bytes) => Some(bytes.as_slice()),
+            None => None,
+        }
+    }
+}

--- a/node/src/types/chainspec/global_state_update.rs
+++ b/node/src/types/chainspec/global_state_update.rs
@@ -14,7 +14,7 @@ use super::error::GlobalStateUpdateLoadError;
 
 #[cfg(test)]
 use crate::testing::TestRng;
-use crate::utils::{self, Loadable};
+use crate::utils;
 
 const GLOBAL_STATE_UPDATE_FILENAME: &str = "global_state.toml";
 
@@ -29,17 +29,20 @@ pub struct GlobalStateUpdateConfig {
     entries: Vec<GlobalStateUpdateEntry>,
 }
 
-impl Loadable for Option<GlobalStateUpdateConfig> {
-    type Error = GlobalStateUpdateLoadError;
-
-    fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error> {
+impl GlobalStateUpdateConfig {
+    /// Returns `Self` and the raw bytes of the file.
+    ///
+    /// If the file doesn't exist, returns `Ok(None)`.
+    pub(super) fn from_dir<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<Option<(Self, Bytes)>, GlobalStateUpdateLoadError> {
         let update_path = path.as_ref().join(GLOBAL_STATE_UPDATE_FILENAME);
         if !update_path.is_file() {
             return Ok(None);
         }
         let bytes = utils::read_file(update_path)?;
-        let toml_update: GlobalStateUpdateConfig = toml::from_slice(&bytes)?;
-        Ok(Some(toml_update))
+        let config: GlobalStateUpdateConfig = toml::from_slice(&bytes)?;
+        Ok(Some((config, Bytes::from(bytes))))
     }
 }
 

--- a/resources/test/rest_schema_chainspec_bytes.json
+++ b/resources/test/rest_schema_chainspec_bytes.json
@@ -23,40 +23,25 @@
   },
   "definitions": {
     "ChainspecRawBytes": {
+      "description": "The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.",
       "type": "object",
       "required": [
-        "chainspec_bytes"
+        "chainspec_bytes",
+        "maybe_genesis_accounts_bytes",
+        "maybe_global_state_bytes"
       ],
       "properties": {
         "chainspec_bytes": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          }
+          "description": "Hex-encoded raw bytes of the current chainspec.toml file.",
+          "type": "string"
         },
         "maybe_genesis_accounts_bytes": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          }
+          "description": "Hex-encoded raw bytes of the current genesis accounts.toml file.",
+          "type": "string"
         },
         "maybe_global_state_bytes": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          }
+          "description": "Hex-encoded raw bytes of the current global_state.toml file.",
+          "type": "string"
         }
       }
     }

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -451,40 +451,25 @@
             "type": "object"
           },
           "ChainspecRawBytes": {
+            "description": "The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.",
             "properties": {
               "chainspec_bytes": {
-                "items": {
-                  "format": "uint8",
-                  "minimum": 0.0,
-                  "type": "integer"
-                },
-                "type": "array"
+                "description": "Hex-encoded raw bytes of the current chainspec.toml file.",
+                "type": "string"
               },
               "maybe_genesis_accounts_bytes": {
-                "items": {
-                  "format": "uint8",
-                  "minimum": 0.0,
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
+                "description": "Hex-encoded raw bytes of the current genesis accounts.toml file.",
+                "type": "string"
               },
               "maybe_global_state_bytes": {
-                "items": {
-                  "format": "uint8",
-                  "minimum": 0.0,
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
+                "description": "Hex-encoded raw bytes of the current global_state.toml file.",
+                "type": "string"
               }
             },
             "required": [
-              "chainspec_bytes"
+              "chainspec_bytes",
+              "maybe_genesis_accounts_bytes",
+              "maybe_global_state_bytes"
             ],
             "type": "object"
           },
@@ -3687,10 +3672,7 @@
                 "value": {
                   "api_version": "1.4.3",
                   "chainspec_bytes": {
-                    "chainspec_bytes": [
-                      42,
-                      42
-                    ],
+                    "chainspec_bytes": "2a2a",
                     "maybe_genesis_accounts_bytes": null,
                     "maybe_global_state_bytes": null
                   }
@@ -3721,7 +3703,7 @@
               "type": "object"
             }
           },
-          "summary": "returns the raw bytes of the chainspec file"
+          "summary": "returns the raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files"
         },
         {
           "examples": [

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -14,12 +14,12 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Added new `bytesrepr::Error::NotRepresentable` error variant that represents values that are not representable by the serialization format.
-* Added new `Key::ChainspecRegistry` key variant under which the ChainspecRegistry is written.
-* Added a new type `WithdrawPurses` which are meant to represent `UnbondingPurses` as they exist in current live networks.
-
+* Add new `bytesrepr::Error::NotRepresentable` error variant that represents values that are not representable by the serialization format.
+* Add new `Key::ChainspecRegistry` key variant under which the `ChainspecRegistry` is written.
+* Add a new type `WithdrawPurses` which is meant to represent `UnbondingPurses` as they exist in current live networks.
 
 ### Changed
+* Extend `UnbondingPurses` to take a new field `new_validator` which represents the validator to whom tokens will be re-delegated.
 * Disable checksummed-hex encoding, but leave checksummed-hex decoding in place.
 * Increase `DICTIONARY_ITEM_KEY_MAX_LENGTH` to 128.
 * Fixed some integer casts.

--- a/utils/global-state-update-gen/src/system_contract_registry.rs
+++ b/utils/global-state-update-gen/src/system_contract_registry.rs
@@ -4,7 +4,7 @@ use clap::ArgMatches;
 use lmdb::{self, Cursor, Environment, EnvironmentFlags, Transaction};
 
 use casper_engine_test_support::LmdbWasmTestBuilder;
-use casper_execution_engine::core::SystemContractRegistry;
+use casper_execution_engine::core::engine_state::SystemContractRegistry;
 use casper_types::{
     bytesrepr::FromBytes,
     system::{AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT},


### PR DESCRIPTION
This has a few changes:
* The chainspec registry (and also for initial disambiguation of types, the system contract registry) are now domain types rather than aliased `BTreeMap`s.
* The chainspec files' raw bytes needed to be read only once: at the point during startup where we parse them.  In this way, even if the operator deletes or changes the files while the node is running, the node will still be able to respond correctly with the file bytes used on startup.  The raw bytes are held in an `Arc` by the chainspec loader.
* The chain synchronizer which effectively calls `commit_upgrade` now passes through a properly formed UpgradeRequest so it need not be mutated by the contract runtime on receipt
* The raw bytes struct now holds the values as `Bytes` so they get automatically hex-encoded when being encoded to JSON.