### PR TITLE
Extend for vm2 entry points.

### DIFF
--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -9,7 +9,7 @@ use casper_types::{
     bytesrepr,
     execution::TransformError,
     system, AccessRights, AddressableEntityHash, ApiError, ByteCodeHash, CLType, CLValueError,
-    EntityVersionKey, Key, PackageHash, StoredValueTypeMismatch, URef,
+    EntityVersionKey, Key, PackageHash, StoredValueTypeMismatch, TransactionRuntime, URef,
 };
 use casper_wasm::elements;
 
@@ -189,6 +189,9 @@ pub enum Error {
     /// Invalid string encoding.
     #[error("Invalid UTF-8 string encoding: {0}")]
     InvalidUtf8Encoding(Utf8Error),
+    /// Incompatible transaction runtime.
+    #[error("Incompatible runtime: {0}")]
+    IncompatibleRuntime(TransactionRuntime),
 }
 
 impl From<PreprocessingError> for Error {

--- a/storage/src/tracking_copy/tests.rs
+++ b/storage/src/tracking_copy/tests.rs
@@ -13,7 +13,8 @@ use casper_types::{
     global_state::TrieMerkleProof,
     handle_stored_dictionary_value, AccessRights, AddressableEntity, ByteCodeHash, CLValue,
     CLValueDictionary, CLValueError, EntityAddr, EntityKind, EntryPoints, HashAddr, Key, KeyTag,
-    PackageHash, ProtocolVersion, StoredValue, URef, U256, U512, UREF_ADDR_LENGTH,
+    PackageHash, ProtocolVersion, StoredValue, TransactionRuntime, URef, U256, U512,
+    UREF_ADDR_LENGTH,
 };
 
 use super::{
@@ -553,7 +554,7 @@ proptest! {
             AssociatedKeys::default(),
             ActionThresholds::default(),
             MessageTopics::default(),
-            EntityKind::SmartContract
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1)
         ));
         let contract_key = Key::AddressableEntity(EntityAddr::SmartContract(hash));
 
@@ -646,7 +647,7 @@ proptest! {
             AssociatedKeys::default(),
             ActionThresholds::default(),
             MessageTopics::default(),
-            EntityKind::SmartContract
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1)
         ));
         let contract_key = Key::AddressableEntity(EntityAddr::SmartContract(hash));
         let contract_named_key = NamedKeyAddr::new_from_string(EntityAddr::SmartContract(hash), state_name.clone())
@@ -743,7 +744,7 @@ fn query_for_circular_references_should_fail() {
         AssociatedKeys::default(),
         ActionThresholds::default(),
         MessageTopics::default(),
-        EntityKind::SmartContract,
+        EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
     ));
 
     let name_key_cl_value = Key::NamedKey(
@@ -818,7 +819,7 @@ fn validate_query_proof_should_work() {
         AssociatedKeys::default(),
         ActionThresholds::default(),
         MessageTopics::default(),
-        EntityKind::SmartContract,
+        EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
     ));
 
     let c_nk = "abc".to_string();
@@ -1073,7 +1074,7 @@ fn query_with_large_depth_with_fixed_path_should_fail() {
             AssociatedKeys::default(),
             ActionThresholds::default(),
             MessageTopics::default(),
-            EntityKind::SmartContract,
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
         ));
         pairs.push((contract_key, contract));
         contract_keys.push(contract_key);
@@ -1140,7 +1141,7 @@ fn query_with_large_depth_with_urefs_should_fail() {
         AssociatedKeys::default(),
         ActionThresholds::default(),
         MessageTopics::default(),
-        EntityKind::SmartContract,
+        EntityKind::SmartContract(casper_types::TransactionRuntime::VmCasperV1),
     ));
     let contract_key = Key::AddressableEntity(contract_addr);
     pairs.push((contract_key, contract));

--- a/types/benches/bytesrepr_bench.rs
+++ b/types/benches/bytesrepr_bench.rs
@@ -14,9 +14,9 @@ use casper_types::{
     system::auction::{Bid, Delegator, EraInfo, SeigniorageAllocation},
     AccessRights, AddressableEntityHash, ByteCodeHash, CLTyped, CLValue, DeployHash, DeployInfo,
     EntityVersionKey, EntityVersions, Gas, Group, Groups, InitiatorAddr, Key, Package, PackageHash,
-    PackageStatus, ProtocolVersion, PublicKey, SecretKey, TransactionHash, TransactionV1Hash,
-    TransferAddr, TransferV2, URef, KEY_HASH_LENGTH, TRANSFER_ADDR_LENGTH, U128, U256, U512,
-    UREF_ADDR_LENGTH,
+    PackageStatus, ProtocolVersion, PublicKey, SecretKey, TransactionHash, TransactionRuntime,
+    TransactionV1Hash, TransferAddr, TransferV2, URef, KEY_HASH_LENGTH, TRANSFER_ADDR_LENGTH, U128,
+    U256, U512, UREF_ADDR_LENGTH,
 };
 
 static KB: usize = 1024;
@@ -468,7 +468,7 @@ fn sample_contract() -> AddressableEntity {
         AssociatedKeys::default(),
         ActionThresholds::default(),
         MessageTopics::default(),
-        EntityKind::SmartContract,
+        EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
     )
 }
 

--- a/types/src/addressable_entity.rs
+++ b/types/src/addressable_entity.rs
@@ -70,8 +70,8 @@ use crate::{
     system::SystemEntityType,
     uref::{self, URef},
     AccessRights, ApiError, CLType, CLTyped, CLValue, CLValueError, ContextAccessRights, HashAddr,
-    Key, KeyTag, PackageHash, ProtocolVersion, PublicKey, Tagged, BLAKE2B_DIGEST_LENGTH,
-    KEY_HASH_LENGTH,
+    Key, KeyTag, PackageHash, ProtocolVersion, PublicKey, Tagged, TransactionRuntime,
+    BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH,
 };
 
 /// Maximum number of distinct user groups.
@@ -634,9 +634,7 @@ impl Distribution<EntityKindTag> for Standard {
     }
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 /// The type of Package.
@@ -646,8 +644,7 @@ pub enum EntityKind {
     /// Package associated with an Account hash.
     Account(AccountHash),
     /// Packages associated with Wasm stored on chain.
-    #[default]
-    SmartContract,
+    SmartContract(TransactionRuntime),
 }
 
 impl EntityKind {
@@ -655,7 +652,7 @@ impl EntityKind {
     pub fn maybe_account_hash(&self) -> Option<AccountHash> {
         match self {
             Self::Account(account_hash) => Some(*account_hash),
-            Self::SmartContract | Self::System(_) => None,
+            Self::SmartContract(_) | Self::System(_) => None,
         }
     }
 
@@ -663,7 +660,7 @@ impl EntityKind {
     pub fn associated_keys(&self) -> AssociatedKeys {
         match self {
             Self::Account(account_hash) => AssociatedKeys::new(*account_hash, Weight::new(1)),
-            Self::SmartContract | Self::System(_) => AssociatedKeys::default(),
+            Self::SmartContract(_) | Self::System(_) => AssociatedKeys::default(),
         }
     }
 
@@ -701,7 +698,7 @@ impl Tagged<EntityKindTag> for EntityKind {
         match self {
             EntityKind::System(_) => EntityKindTag::System,
             EntityKind::Account(_) => EntityKindTag::Account,
-            EntityKind::SmartContract => EntityKindTag::SmartContract,
+            EntityKind::SmartContract(_) => EntityKindTag::SmartContract,
         }
     }
 }
@@ -723,7 +720,9 @@ impl ToBytes for EntityKind {
     fn serialized_length(&self) -> usize {
         U8_SERIALIZED_LENGTH
             + match self {
-                EntityKind::SmartContract => 0,
+                EntityKind::SmartContract(transaction_runtime) => {
+                    transaction_runtime.serialized_length()
+                }
                 EntityKind::System(system_entity_type) => system_entity_type.serialized_length(),
                 EntityKind::Account(account_hash) => account_hash.serialized_length(),
             }
@@ -731,9 +730,9 @@ impl ToBytes for EntityKind {
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         match self {
-            EntityKind::SmartContract => {
+            EntityKind::SmartContract(transaction_runtime) => {
                 writer.push(self.tag());
-                Ok(())
+                transaction_runtime.write_bytes(writer)
             }
             EntityKind::System(system_entity_type) => {
                 writer.push(self.tag());
@@ -759,7 +758,10 @@ impl FromBytes for EntityKind {
                 let (account_hash, remainder) = AccountHash::from_bytes(remainder)?;
                 Ok((EntityKind::Account(account_hash), remainder))
             }
-            EntityKindTag::SmartContract => Ok((EntityKind::SmartContract, remainder)),
+            EntityKindTag::SmartContract => {
+                let (transaction_runtime, remainder) = TransactionRuntime::from_bytes(remainder)?;
+                Ok((EntityKind::SmartContract(transaction_runtime), remainder))
+            }
         }
     }
 }
@@ -773,8 +775,8 @@ impl Display for EntityKind {
             EntityKind::Account(account_hash) => {
                 write!(f, "account-entity-kind({})", account_hash)
             }
-            EntityKind::SmartContract => {
-                write!(f, "smart-contract-entity-kind")
+            EntityKind::SmartContract(transaction_runtime) => {
+                write!(f, "smart-contract-entity-kind({})", transaction_runtime)
             }
         }
     }
@@ -786,7 +788,7 @@ impl Distribution<EntityKind> for Standard {
         match rng.gen_range(0..=2) {
             0 => EntityKind::System(rng.gen()),
             1 => EntityKind::Account(rng.gen()),
-            2 => EntityKind::SmartContract,
+            2 => EntityKind::SmartContract(rng.gen()),
             _ => unreachable!(),
         }
     }
@@ -829,7 +831,7 @@ impl EntityAddr {
         match entity_kind {
             EntityKind::System(_) => Self::new_system(hash_addr),
             EntityKind::Account(_) => Self::new_account(hash_addr),
-            EntityKind::SmartContract => Self::new_smart_contract(hash_addr),
+            EntityKind::SmartContract(_) => Self::new_smart_contract(hash_addr),
         }
     }
 
@@ -1386,8 +1388,6 @@ pub struct AddressableEntity {
     package_hash: PackageHash,
     byte_code_hash: ByteCodeHash,
     main_purse: URef,
-
-    // entry_points: EntryPoints,
     associated_keys: AssociatedKeys,
     action_thresholds: ActionThresholds,
     message_topics: MessageTopics,
@@ -1446,7 +1446,7 @@ impl AddressableEntity {
         match self.entity_kind {
             EntityKind::System(_) => EntityAddr::new_system(hash_addr),
             EntityKind::Account(_) => EntityAddr::new_account(hash_addr),
-            EntityKind::SmartContract => EntityAddr::new_smart_contract(hash_addr),
+            EntityKind::SmartContract(_) => EntityAddr::new_smart_contract(hash_addr),
         }
     }
 
@@ -1694,7 +1694,7 @@ impl AddressableEntity {
             EntityKind::Account(_) => {
                 Key::addressable_entity_key(EntityKindTag::Account, entity_hash)
             }
-            EntityKind::SmartContract => {
+            EntityKind::SmartContract(_) => {
                 Key::addressable_entity_key(EntityKindTag::SmartContract, entity_hash)
             }
         }
@@ -1795,7 +1795,7 @@ impl Default for AddressableEntity {
             action_thresholds: ActionThresholds::default(),
             associated_keys: AssociatedKeys::default(),
             message_topics: MessageTopics::default(),
-            entity_kind: EntityKind::SmartContract,
+            entity_kind: EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
         }
     }
 }
@@ -1810,7 +1810,7 @@ impl From<Contract> for AddressableEntity {
             AssociatedKeys::default(),
             ActionThresholds::default(),
             MessageTopics::default(),
-            EntityKind::SmartContract,
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
         )
     }
 }
@@ -1934,7 +1934,7 @@ mod tests {
             ActionThresholds::new(Weight::new(1), Weight::new(1), Weight::new(1))
                 .expect("should create thresholds"),
             MessageTopics::default(),
-            EntityKind::SmartContract,
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
         );
         let access_rights = contract.extract_access_rights(entity_hash, &named_keys);
         let expected_uref = URef::new([42; UREF_ADDR_LENGTH], AccessRights::READ_ADD_WRITE);

--- a/types/src/addressable_entity/entry_points.rs
+++ b/types/src/addressable_entity/entry_points.rs
@@ -532,39 +532,41 @@ impl KeyValueJsonSchema for EntryPointLabels {
     const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("NamedEntryPoint");
 }
 
+/// The entry point for the V2 Casper VM.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct EntryPointV2 {
-    pub selector: u32,
+    /// The selector.
     pub function_index: u32,
+    /// The flags.
     pub flags: u32,
 }
 
 impl ToBytes for EntryPointV2 {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.append(&mut self.selector.to_bytes()?);
-        buffer.append(&mut self.function_index.to_bytes()?);
-        buffer.append(&mut self.flags.to_bytes()?);
+        self.write_bytes(&mut buffer)?;
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.selector.serialized_length()
-            + self.function_index.serialized_length()
-            + self.flags.serialized_length()
+        self.function_index.serialized_length() + self.flags.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        writer.append(&mut self.function_index.to_bytes()?);
+        writer.append(&mut self.flags.to_bytes()?);
+        Ok(())
     }
 }
 
 impl FromBytes for EntryPointV2 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (selector, remainder) = u32::from_bytes(bytes)?;
-        let (function_index, remainder) = u32::from_bytes(remainder)?;
+        let (function_index, remainder) = u32::from_bytes(bytes)?;
         let (flags, remainder) = u32::from_bytes(remainder)?;
         Ok((
             EntryPointV2 {
-                selector,
                 function_index,
                 flags,
             },
@@ -827,16 +829,7 @@ impl EntryPointValue {
 impl ToBytes for EntryPointValue {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
-        match self {
-            EntryPointValue::V1CasperVm(entry_point) => {
-                buffer.insert(0, V1_ENTRY_POINT_TAG);
-                buffer.append(&mut entry_point.to_bytes()?);
-            }
-            EntryPointValue::V2CasperVm(entry_point) => {
-                buffer.insert(0, V2_ENTRY_POINT_TAG);
-                buffer.append(&mut entry_point.to_bytes()?);
-            }
-        }
+        self.write_bytes(&mut buffer)?;
         Ok(buffer)
     }
 
@@ -846,6 +839,20 @@ impl ToBytes for EntryPointValue {
                 EntryPointValue::V1CasperVm(entry_point) => entry_point.serialized_length(),
                 EntryPointValue::V2CasperVm(entry_point) => entry_point.serialized_length(),
             }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        match self {
+            EntryPointValue::V1CasperVm(entry_point) => {
+                writer.push(V1_ENTRY_POINT_TAG);
+                entry_point.write_bytes(writer)?;
+            }
+            EntryPointValue::V2CasperVm(entry_point) => {
+                writer.push(V2_ENTRY_POINT_TAG);
+                entry_point.write_bytes(writer)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -863,5 +870,23 @@ impl FromBytes for EntryPointValue {
             }
             _ => Err(Error::Formatting),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn entry_point_type_serialization_roundtrip() {
+        let vm1 = EntryPointAddr::VmCasperV1 {
+            entity_addr: EntityAddr::new_smart_contract([42; 32]),
+            name_bytes: [99; 32],
+        };
+        bytesrepr::test_serialization_roundtrip(&vm1);
+        let vm2 = EntryPointAddr::VmCasperV2 {
+            entity_addr: EntityAddr::new_smart_contract([42; 32]),
+            selector: u32::MAX,
+        };
+        bytesrepr::test_serialization_roundtrip(&vm2);
     }
 }

--- a/utils/validation/src/generators.rs
+++ b/utils/validation/src/generators.rs
@@ -22,7 +22,7 @@ use casper_types::{
     CLTyped, CLValue, DeployHash, DeployInfo, EntityVersionKey, EntityVersions, EntryPoint,
     EntryPointAccess, EntryPointType, EntryPointValue, EraId, Group, Groups, Key, Package,
     PackageHash, PackageStatus, Parameter, ProtocolVersion, PublicKey, SecretKey, StoredValue,
-    TransferAddr, TransferV1, URef, U512,
+    TransactionRuntime, TransferAddr, TransferV1, URef, U512,
 };
 use casper_validation::{
     abi::{ABIFixture, ABITestCase},
@@ -379,7 +379,7 @@ pub fn make_abi_test_fixtures() -> Result<TestFixtures, Error> {
             AssociatedKeys::default(),
             ActionThresholds::default(),
             MessageTopics::default(),
-            EntityKind::SmartContract,
+            EntityKind::SmartContract(TransactionRuntime::VmCasperV1),
         );
         stored_value.insert(
             "AddressableEntity".to_string(),


### PR DESCRIPTION
- `EntityKind::SmartContract` now holds a `TransactionRuntime` variant
- Execution Engine returns `IncompatibleRuntime` when a V2 stored contract is going to be executed.
- Some improvements to serialization tests
- Changed TransactionV2 to remove selector as the selector is part of the key