### PR TITLE
Migrate entry points 2

### DIFF
--- a/execution_engine/src/engine_state/wasm_v1.rs
+++ b/execution_engine/src/engine_state/wasm_v1.rs
@@ -630,6 +630,15 @@ impl TryFrom<&TransactionV1> for PaymentInfo {
                     mode.to_string(),
                 ));
             }
+            PricingMode::GasLimited { gas_limit, .. } => {
+                if !v1_txn.is_v2_wasm() {
+                    return Err(InvalidRequest::UnsupportedMode(
+                        transaction_hash,
+                        pricing_mode.to_string(),
+                    ));
+                }
+                *gas_limit
+            }
         };
 
         let payment = match v1_txn.target() {

--- a/execution_engine/src/engine_state/wasm_v1.rs
+++ b/execution_engine/src/engine_state/wasm_v1.rs
@@ -33,6 +33,9 @@ pub enum InvalidRequest {
     /// Invalid target.
     #[error("invalid target for {0} attempting {1}")]
     InvalidTarget(TransactionHash, String),
+    /// Invalid runtime.
+    #[error("invalid runtime for {0}")]
+    InvalidRuntime(TransactionHash),
 }
 
 /// The item to be executed.
@@ -474,7 +477,13 @@ impl TryFrom<&TransactionV1> for SessionInfo {
 
     fn try_from(v1_txn: &TransactionV1) -> Result<Self, Self::Error> {
         let transaction_hash = TransactionHash::V1(*v1_txn.hash());
-        let args = v1_txn.args().clone();
+        let args = match v1_txn.args() {
+            Some(args) => args,
+            None => {
+                return Err(InvalidRequest::InvalidRuntime(transaction_hash));
+            }
+        };
+
         let session = match v1_txn.target() {
             TransactionTarget::Native => {
                 return Err(InvalidRequest::InvalidTarget(
@@ -498,7 +507,7 @@ impl TryFrom<&TransactionV1> for SessionInfo {
         Ok(SessionInfo(ExecutableInfo {
             item: session,
             entry_point: entry_point.clone(),
-            args,
+            args: args.clone(),
         }))
     }
 }

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, convert::TryInto, sync::Arc, time::Instant};
 use itertools::Itertools;
 use tracing::{debug, error, info, trace, warn};
 
-use casper_execution_engine::engine_state::{ExecutionEngineV1, WasmV1Request, WasmV1Result};
+use casper_execution_engine::engine_state::{
+    ExecutionEngineV1, InvalidRequest, WasmV1Request, WasmV1Result,
+};
 use casper_storage::{
     block_store::types::ApprovalsHashes,
     data_access_layer::{
@@ -141,7 +143,18 @@ pub fn execute_finalized_block(
 
         let initiator_addr = transaction.initiator_addr();
         let transaction_hash = transaction.hash();
-        let runtime_args = transaction.session_args().clone();
+        let runtime_args = match transaction.session_args() {
+            Some(args) => args.clone(),
+            None => {
+                debug!(%transaction_hash, "invalid transaction due to wrong runtime (missing runtime args)");
+                artifact_builder.with_invalid_wasm_v1_request(&InvalidRequest::InvalidRuntime(
+                    transaction.hash(),
+                ));
+                artifacts.push(artifact_builder.build());
+                continue;
+            }
+        };
+
         let entry_point = transaction.entry_point();
         let authorization_keys = transaction.authorization_keys();
 

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -583,7 +583,8 @@ impl TransactionAcceptor {
                 | TransactionEntryPoint::Undelegate
                 | TransactionEntryPoint::Redelegate
                 | TransactionEntryPoint::ActivateBid
-                | TransactionEntryPoint::ChangeBidPublicKey => None,
+                | TransactionEntryPoint::ChangeBidPublicKey
+                | TransactionEntryPoint::Selector(_) => None,
             },
         };
 

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -184,6 +184,8 @@ block_gas_limit = 10_000_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 # The maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the config.toml file.
 max_timestamp_leeway = '5 seconds'
+# Configuration of the transaction runtime.
+runtime = "VmCasperV1"
 
 [transactions.v1]
 # The maximum length in bytes of runtime args per V1 transaction.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -194,6 +194,8 @@ block_gas_limit = 4_000_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 # The maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the config.toml file.
 max_timestamp_leeway = '5 seconds'
+# Configuration of the transaction runtime.
+runtime = "VmCasperV1"
 
 [transactions.v1]
 # The maximum length in bytes of runtime args per V1 transaction.

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -46,6 +46,7 @@ max_block_size = 10_485_760
 block_gas_limit = 10_000_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 max_timestamp_leeway = '5 seconds'
+runtime = "VmCasperV1"
 
 [transactions.v1]
 max_args_length = 1024

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -39,6 +39,7 @@ reduced_reward_multiplier = [1, 5]
 [transactions]
 max_ttl = '18hours'
 max_transaction_size = 1_048_576
+runtime = "VmCasperV1"
 block_max_deploy_count = 50
 block_max_native_count = 1250
 block_max_approval_count = 2600

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -46,6 +46,7 @@ max_block_size = 10_485_760
 block_gas_limit = 10_000_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 max_timestamp_leeway = '5 seconds'
+runtime = "VmCasperV1"
 
 [transactions.v1]
 max_args_length = 1024

--- a/storage/src/data_access_layer/auction.rs
+++ b/storage/src/data_access_layer/auction.rs
@@ -82,7 +82,9 @@ impl AuctionMethod {
         chainspec: &Chainspec,
     ) -> Result<Self, AuctionMethodError> {
         match entry_point {
-            TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Transfer => {
+            TransactionEntryPoint::Custom(_)
+            | TransactionEntryPoint::Selector(_)
+            | TransactionEntryPoint::Transfer => {
                 Err(AuctionMethodError::InvalidEntryPoint(entry_point))
             }
             TransactionEntryPoint::ActivateBid => Self::new_activate_bid(runtime_args),

--- a/types/src/block/test_block_builder/test_block_v2_builder.rs
+++ b/types/src/block/test_block_builder/test_block_v2_builder.rs
@@ -188,7 +188,7 @@ impl TestBlockV2Builder {
                 }
                 Transaction::V1(v1_txn) => match v1_txn.target() {
                     TransactionTarget::Native => match v1_txn.entry_point() {
-                        TransactionEntryPoint::Custom(_) => {
+                        TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Selector(_) => {
                             panic!("custom entry point not supported for native target")
                         }
                         TransactionEntryPoint::Transfer => transfer_hashes.push(txn_hash),

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -358,9 +358,9 @@ impl Transaction {
     }
 
     /// The session args.
-    pub fn session_args(&self) -> &RuntimeArgs {
+    pub fn session_args(&self) -> Option<&RuntimeArgs> {
         match self {
-            Transaction::Deploy(deploy) => deploy.session().args(),
+            Transaction::Deploy(deploy) => Some(deploy.session().args()),
             Transaction::V1(transaction_v1) => transaction_v1.body().args(),
         }
     }

--- a/types/src/transaction/pricing_mode.rs
+++ b/types/src/transaction/pricing_mode.rs
@@ -21,6 +21,7 @@ use crate::{
 const CLASSIC_TAG: u8 = 0;
 const FIXED_TAG: u8 = 1;
 const RESERVED_TAG: u8 = 2;
+const GAS_LIMITED_TAG: u8 = 3;
 
 /// The pricing mode of a [`Transaction`].
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
@@ -58,13 +59,27 @@ pub enum PricingMode {
         /// Pre-paid receipt.
         receipt: Digest,
     },
+    /// Executing this transaction will stop exactly after `gas_limit` gas is used.
+    ///
+    /// This is used for `VmCasperV2` transactions where there is no payment code, and gas limit is
+    /// used to determine upper bounds of the computation.
+    GasLimited {
+        /// User-specified limit that will be deducted from the account's balance and means that
+        /// the transaction will stop executing once gas limit is reached. Any unused gas will be
+        /// refunded as according to the current chain settings.
+        gas_limit: u64,
+        /// User-specified gas_price tolerance (minimum 1).
+        /// This is interpreted to mean "do not include this transaction in a block
+        /// if the current gas price is greater than this number"
+        gas_price_tolerance: u8,
+    },
 }
 
 impl PricingMode {
     /// Returns a random `PricingMode.
     #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
-        match rng.gen_range(0..3) {
+        match rng.gen_range(0..=4) {
             0 => PricingMode::Classic {
                 payment_amount: rng.gen(),
                 gas_price_tolerance: 1,
@@ -73,7 +88,15 @@ impl PricingMode {
             1 => PricingMode::Fixed {
                 gas_price_tolerance: rng.gen(),
             },
-            2 => PricingMode::Reserved { receipt: rng.gen() },
+            2 => PricingMode::Reserved {
+                receipt: rng.gen(),
+                paid_amount: rng.gen(),
+                strike_price: rng.gen(),
+            },
+            3 => PricingMode::GasLimited {
+                gas_limit: rng.gen(),
+                gas_price_tolerance: rng.gen(),
+            },
             _ => unreachable!(),
         }
     }
@@ -97,6 +120,14 @@ impl Display for PricingMode {
             PricingMode::Fixed {
                 gas_price_tolerance,
             } => write!(formatter, "fixed pricing {}", gas_price_tolerance),
+            PricingMode::GasLimited {
+                gas_limit,
+                gas_price_tolerance,
+            } => write!(
+                formatter,
+                "gas limited: {} gas price multiplier {}",
+                gas_limit, gas_price_tolerance
+            ),
         }
     }
 }
@@ -124,6 +155,14 @@ impl ToBytes for PricingMode {
                 FIXED_TAG.write_bytes(writer)?;
                 gas_price_tolerance.write_bytes(writer)
             }
+            PricingMode::GasLimited {
+                gas_limit,
+                gas_price_tolerance,
+            } => {
+                GAS_LIMITED_TAG.write_bytes(writer)?;
+                gas_limit.write_bytes(writer)?;
+                gas_price_tolerance.write_bytes(writer)
+            }
         }
     }
 
@@ -149,6 +188,10 @@ impl ToBytes for PricingMode {
                 PricingMode::Fixed {
                     gas_price_tolerance,
                 } => gas_price_tolerance.serialized_length(),
+                PricingMode::GasLimited {
+                    gas_limit,
+                    gas_price_tolerance,
+                } => gas_limit.serialized_length() + gas_price_tolerance.serialized_length(),
             }
     }
 }
@@ -184,6 +227,17 @@ impl FromBytes for PricingMode {
                 let (receipt, remainder) = Digest::from_bytes(remainder)?;
                 Ok((PricingMode::Reserved { receipt }, remainder))
             }
+            GAS_LIMITED_TAG => {
+                let (gas_limit, remainder) = u64::from_bytes(remainder)?;
+                let (gas_price_tolerance, remainder) = u8::from_bytes(remainder)?;
+                Ok((
+                    PricingMode::GasLimited {
+                        gas_limit,
+                        gas_price_tolerance,
+                    },
+                    remainder,
+                ))
+            }
             _ => Err(bytesrepr::Error::Formatting),
         }
     }
@@ -192,13 +246,29 @@ impl FromBytes for PricingMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::TestRng;
 
     #[test]
     fn bytesrepr_roundtrip() {
-        let rng = &mut TestRng::new();
-        for _ in 0..10 {
-            bytesrepr::test_serialization_roundtrip(&PricingMode::random(rng));
+        for pricing_mode in [
+            PricingMode::Classic {
+                payment_amount: 2,
+                gas_price_tolerance: 1,
+                standard_payment: true,
+            },
+            PricingMode::Fixed {
+                gas_price_tolerance: 1,
+            },
+            PricingMode::Reserved {
+                receipt: Digest::hash("hello, world"),
+                paid_amount: 2,
+                strike_price: 1,
+            },
+            PricingMode::GasLimited {
+                gas_limit: 2,
+                gas_price_tolerance: 1,
+            },
+        ] {
+            bytesrepr::test_serialization_roundtrip(&pricing_mode);
         }
     }
 }

--- a/types/src/transaction/pricing_mode.rs
+++ b/types/src/transaction/pricing_mode.rs
@@ -90,8 +90,6 @@ impl PricingMode {
             },
             2 => PricingMode::Reserved {
                 receipt: rng.gen(),
-                paid_amount: rng.gen(),
-                strike_price: rng.gen(),
             },
             3 => PricingMode::GasLimited {
                 gas_limit: rng.gen(),
@@ -260,8 +258,6 @@ mod tests {
             },
             PricingMode::Reserved {
                 receipt: Digest::hash("hello, world"),
-                paid_amount: 2,
-                strike_price: 1,
             },
             PricingMode::GasLimited {
                 gas_limit: 2,

--- a/types/src/transaction/transaction_target.rs
+++ b/types/src/transaction/transaction_target.rs
@@ -95,6 +95,15 @@ impl TransactionTarget {
             _ => unreachable!(),
         }
     }
+
+    /// Returns the runtime of the transaction target, if any.
+    pub fn runtime(&self) -> Option<&TransactionRuntime> {
+        match self {
+            TransactionTarget::Native => None,
+            TransactionTarget::Stored { runtime, .. } => Some(runtime),
+            TransactionTarget::Session { runtime, .. } => Some(runtime),
+        }
+    }
 }
 
 impl Display for TransactionTarget {

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -620,7 +620,9 @@ impl TransactionV1 {
     pub fn transaction_category(&self) -> TransactionCategory {
         match self.body().target() {
             TransactionTarget::Native => match self.body().entry_point() {
-                TransactionEntryPoint::Custom(_) => TransactionCategory::Standard,
+                TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Selector(_) => {
+                    TransactionCategory::Standard
+                }
                 TransactionEntryPoint::Transfer => TransactionCategory::Mint,
                 TransactionEntryPoint::AddBid
                 | TransactionEntryPoint::WithdrawBid
@@ -694,11 +696,14 @@ impl GasLimited for TransactionV1 {
                     } else if self.is_native_auction() {
                         let entry_point = self.body().entry_point();
                         let amount = match entry_point {
-                            TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Transfer => {
+                            TransactionEntryPoint::Custom(_)
+                            | TransactionEntryPoint::Transfer
+                            | TransactionEntryPoint::Selector(_) => {
                                 return Err(InvalidTransactionV1::EntryPointCannotBeCustom {
                                     entry_point: entry_point.clone(),
                                 })
                             }
+
                             TransactionEntryPoint::AddBid | TransactionEntryPoint::ActivateBid => {
                                 costs.auction_costs().add_bid.into()
                             }

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -1,4 +1,5 @@
 mod errors_v1;
+mod transaction_v1_args;
 mod transaction_v1_body;
 #[cfg(any(feature = "std", test))]
 mod transaction_v1_builder;
@@ -48,6 +49,7 @@ pub use errors_v1::{
     ExcessiveSizeErrorV1 as TransactionV1ExcessiveSizeError,
     InvalidTransaction as InvalidTransactionV1,
 };
+pub use transaction_v1_args::TransactionArgs;
 pub use transaction_v1_body::TransactionV1Body;
 #[cfg(any(feature = "std", test))]
 pub use transaction_v1_builder::{TransactionV1Builder, TransactionV1BuilderError};
@@ -180,12 +182,12 @@ impl TransactionV1 {
     }
 
     /// Returns the runtime args of the transaction.
-    pub fn args(&self) -> &RuntimeArgs {
+    pub fn args(&self) -> Option<&RuntimeArgs> {
         self.body.args()
     }
 
     /// Consumes `self`, returning the runtime args of the transaction.
-    pub fn take_args(self) -> RuntimeArgs {
+    pub fn take_args(self) -> Option<RuntimeArgs> {
         self.body.take_args()
     }
 
@@ -364,6 +366,22 @@ impl TransactionV1 {
         self.is_valid_size(transaction_config.max_transaction_size)?;
 
         let chain_name = chainspec.network_config.name.clone();
+
+        let body = self.body();
+        if let Some(runtime) = body.target().runtime() {
+            if *runtime != chainspec.transaction_config.transaction_runtime {
+                debug!(
+                    transaction_hash = %self.hash(),
+                    transaction_header = %self.header(),
+                    runtime = ?runtime,
+                    "invalid transaction runtime"
+                );
+                return Err(InvalidTransactionV1::InvalidRuntime {
+                    expected: chainspec.transaction_config.transaction_runtime,
+                    got: *runtime,
+                });
+            }
+        };
 
         let header = self.header();
         if header.chain_name() != chain_name {

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -13,7 +13,10 @@ use serde::Serialize;
 use super::super::TransactionEntryPoint;
 #[cfg(doc)]
 use super::TransactionV1;
-use crate::{bytesrepr, crypto, CLType, DisplayIter, PricingMode, TimeDiff, Timestamp, U512};
+use crate::{
+    bytesrepr, crypto, CLType, DisplayIter, PricingMode, TimeDiff, Timestamp, TransactionRuntime,
+    U512,
+};
 
 /// Returned when a [`TransactionV1`] fails validation.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -152,6 +155,13 @@ pub enum InvalidTransaction {
         /// The pricing mode as specified by the transaction.
         price_mode: PricingMode,
     },
+    /// The runtime specified in the transaction is invalid.
+    InvalidRuntime {
+        /// The expected runtime.
+        expected: TransactionRuntime,
+        /// The runtime specified in the transaction.
+        got: TransactionRuntime,
+    },
 }
 
 impl Display for InvalidTransaction {
@@ -281,6 +291,9 @@ impl Display for InvalidTransaction {
                     "received a transaction with an invalid mode {price_mode}"
                 )
             }
+            InvalidTransaction::InvalidRuntime { expected, got } => {
+                write!(formatter, "invalid runtime: expected {expected}, got {got}")
+            }
         }
     }
 }
@@ -316,7 +329,8 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::GasPriceConversion { .. }
             | InvalidTransaction::UnableToCalculateGasLimit
             | InvalidTransaction::UnableToCalculateGasCost
-            | InvalidTransaction::InvalidPricingMode { .. } => None,
+            | InvalidTransaction::InvalidPricingMode { .. }
+            | InvalidTransaction::InvalidRuntime { .. } => None,
         }
     }
 }

--- a/types/src/transaction/transaction_v1/transaction_v1_args.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_args.rs
@@ -1,0 +1,101 @@
+use alloc::vec::Vec;
+
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+#[cfg(any(feature = "std", test))]
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    bytesrepr::{self, Bytes, FromBytes, ToBytes},
+    RuntimeArgs,
+};
+
+const NAMED_ARGUMENTS_TAG: u8 = 0;
+const BYTES_TAG: u8 = 1;
+
+/// Arguments of a `TransactionV1`.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(
+    any(feature = "std", test),
+    derive(Serialize, Deserialize),
+    serde(deny_unknown_fields)
+)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(
+    feature = "json-schema",
+    derive(JsonSchema),
+    schemars(description = "Arguments of a `TransactionV1`.")
+)]
+pub enum TransactionArgs {
+    /// Arguments passed by name.
+    ///
+    /// This is the most common way to pass arguments to a contract used in a `VmCasperV1` runtime.
+    NamedArguments(RuntimeArgs),
+    /// Arguments passed as a single byte array.
+    ///
+    /// This is used in the `VmCapserV2` runtime.
+    Bytes(Bytes),
+}
+
+impl ToBytes for TransactionArgs {
+    fn write_bytes(&self, bytes: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            TransactionArgs::NamedArguments(named_args) => {
+                bytes.push(NAMED_ARGUMENTS_TAG);
+                named_args.write_bytes(bytes)?;
+            }
+            TransactionArgs::Bytes(input_bytes) => {
+                bytes.push(BYTES_TAG);
+                input_bytes.write_bytes(bytes)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut bytes = Vec::new();
+        self.write_bytes(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    fn serialized_length(&self) -> usize {
+        1 + match self {
+            TransactionArgs::NamedArguments(named_args) => named_args.serialized_length(),
+            TransactionArgs::Bytes(bytes) => bytes.serialized_length(),
+        }
+    }
+}
+impl FromBytes for TransactionArgs {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem) = u8::from_bytes(bytes)?;
+        match tag {
+            NAMED_ARGUMENTS_TAG => {
+                let (named_args, rem) = RuntimeArgs::from_bytes(rem)?;
+                Ok((TransactionArgs::NamedArguments(named_args), rem))
+            }
+            BYTES_TAG => {
+                let (bytes, rem) = Bytes::from_bytes(rem)?;
+                Ok((TransactionArgs::Bytes(bytes), rem))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization_roundtrip() {
+        let named_args = RuntimeArgs::new();
+        let input = TransactionArgs::NamedArguments(named_args);
+        bytesrepr::test_serialization_roundtrip(&input);
+
+        let bytes = Bytes::from(vec![1, 2, 3]);
+        let input = TransactionArgs::Bytes(bytes);
+        bytesrepr::test_serialization_roundtrip(&input);
+    }
+}

--- a/types/src/transaction/transaction_v1/transaction_v1_args.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_args.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bytesrepr::{self, Bytes, FromBytes, ToBytes},
-    RuntimeArgs,
+    RuntimeArgs, U512,
 };
 
 const NAMED_ARGUMENTS_TAG: u8 = 0;
@@ -32,23 +32,40 @@ pub enum TransactionArgs {
     /// Arguments passed by name.
     ///
     /// This is the most common way to pass arguments to a contract used in a `VmCasperV1` runtime.
-    NamedArguments(RuntimeArgs),
+    VmCasperV1(RuntimeArgs),
     /// Arguments passed as a single byte array.
     ///
-    /// This is used in the `VmCapserV2` runtime.
-    Bytes(Bytes),
+    /// This is used in the `VmCasperV2` runtime.
+    VmCasperV2 {
+        /// The tokens that are available to use inside the execution environment for transfers.
+        ///
+        /// This is introduced in favor of V1's `named_args` and implicit "amount" argument that
+        /// was used as token allowance.
+        ///
+        /// Passing 0 effectively removes the token usage from the execution environment, and the
+        /// contract will not be able to transfer tokens. This is useful security measure
+        /// to prevent accidental token transfers from possibly untrusted contract calls.
+        ///
+        /// Otherwise if the value is greater than 0, the contract will be able to transfer tokens
+        /// up to the value specified. Additionally, the contract will be able to read the current
+        /// balance of the caller using the `casper_env_value` host function.
+        value: U512,
+        /// The byte array containing the arguments.
+        input: Bytes,
+    },
 }
 
 impl ToBytes for TransactionArgs {
     fn write_bytes(&self, bytes: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         match self {
-            TransactionArgs::NamedArguments(named_args) => {
+            TransactionArgs::VmCasperV1(named_args) => {
                 bytes.push(NAMED_ARGUMENTS_TAG);
                 named_args.write_bytes(bytes)?;
             }
-            TransactionArgs::Bytes(input_bytes) => {
+            TransactionArgs::VmCasperV2 { value, input } => {
                 bytes.push(BYTES_TAG);
-                input_bytes.write_bytes(bytes)?;
+                value.write_bytes(bytes)?;
+                input.write_bytes(bytes)?;
             }
         }
         Ok(())
@@ -62,8 +79,10 @@ impl ToBytes for TransactionArgs {
 
     fn serialized_length(&self) -> usize {
         1 + match self {
-            TransactionArgs::NamedArguments(named_args) => named_args.serialized_length(),
-            TransactionArgs::Bytes(bytes) => bytes.serialized_length(),
+            TransactionArgs::VmCasperV1(named_args) => named_args.serialized_length(),
+            TransactionArgs::VmCasperV2 { value, input } => {
+                value.serialized_length() + input.serialized_length()
+            }
         }
     }
 }
@@ -73,11 +92,12 @@ impl FromBytes for TransactionArgs {
         match tag {
             NAMED_ARGUMENTS_TAG => {
                 let (named_args, rem) = RuntimeArgs::from_bytes(rem)?;
-                Ok((TransactionArgs::NamedArguments(named_args), rem))
+                Ok((TransactionArgs::VmCasperV1(named_args), rem))
             }
             BYTES_TAG => {
-                let (bytes, rem) = Bytes::from_bytes(rem)?;
-                Ok((TransactionArgs::Bytes(bytes), rem))
+                let (value, rem) = U512::from_bytes(rem)?;
+                let (input, rem) = Bytes::from_bytes(rem)?;
+                Ok((TransactionArgs::VmCasperV2 { value, input }, rem))
             }
             _ => Err(bytesrepr::Error::Formatting),
         }
@@ -91,11 +111,14 @@ mod tests {
     #[test]
     fn serialization_roundtrip() {
         let named_args = RuntimeArgs::new();
-        let input = TransactionArgs::NamedArguments(named_args);
+        let input = TransactionArgs::VmCasperV1(named_args);
         bytesrepr::test_serialization_roundtrip(&input);
 
-        let bytes = Bytes::from(vec![1, 2, 3]);
-        let input = TransactionArgs::Bytes(bytes);
+        let input = Bytes::from(vec![1, 2, 3]);
+        let input = TransactionArgs::VmCasperV2 {
+            value: U512::from(u64::MAX) + U512::one(),
+            input,
+        };
         bytesrepr::test_serialization_roundtrip(&input);
     }
 }

--- a/types/src/transaction/transaction_v1/transaction_v1_body.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body.rs
@@ -227,7 +227,7 @@ impl TransactionV1Body {
                     arg_handling::has_valid_activate_bid_args(args)
                 }
                 TransactionEntryPoint::ChangeBidPublicKey => {
-                    arg_handling::has_valid_change_bid_public_key_args(&self.args)
+                    arg_handling::has_valid_change_bid_public_key_args(args)
                 }
             },
             TransactionTarget::Stored { .. } => match &self.entry_point {

--- a/types/src/transaction/transaction_v1/transaction_v1_body.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body.rs
@@ -119,7 +119,9 @@ impl TransactionV1Body {
             return false;
         }
         match self.entry_point {
-            TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Transfer => false,
+            TransactionEntryPoint::Custom(_)
+            | TransactionEntryPoint::Selector(_)
+            | TransactionEntryPoint::Transfer => false,
             TransactionEntryPoint::AddBid
             | TransactionEntryPoint::WithdrawBid
             | TransactionEntryPoint::ActivateBid
@@ -200,7 +202,7 @@ impl TransactionV1Body {
 
         match &self.target {
             TransactionTarget::Native => match self.entry_point {
-                TransactionEntryPoint::Custom(_) => {
+                TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Selector(_) => {
                     debug!(
                         entry_point = %self.entry_point,
                         "native transaction cannot have custom entry point"
@@ -209,6 +211,7 @@ impl TransactionV1Body {
                         entry_point: self.entry_point.clone(),
                     })
                 }
+
                 TransactionEntryPoint::Transfer => arg_handling::has_valid_transfer_args(
                     args,
                     config.native_transfer_minimum_motes,
@@ -228,7 +231,7 @@ impl TransactionV1Body {
                 }
             },
             TransactionTarget::Stored { .. } => match &self.entry_point {
-                TransactionEntryPoint::Custom(_) => Ok(()),
+                TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Selector(_) => Ok(()),
                 TransactionEntryPoint::Transfer
                 | TransactionEntryPoint::AddBid
                 | TransactionEntryPoint::WithdrawBid
@@ -247,7 +250,7 @@ impl TransactionV1Body {
                 }
             },
             TransactionTarget::Session { module_bytes, .. } => match &self.entry_point {
-                TransactionEntryPoint::Custom(_) => {
+                TransactionEntryPoint::Custom(_) | TransactionEntryPoint::Selector(_) => {
                     if module_bytes.is_empty() {
                         debug!("transaction with session code must not have empty module bytes");
                         return Err(InvalidTransactionV1::EmptyModuleBytes);

--- a/types/src/transaction/transaction_v1/transaction_v1_builder.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_builder.rs
@@ -381,13 +381,13 @@ impl<'a> TransactionV1Builder<'a> {
     /// Appends the given runtime arg into the body's `args`.
     pub fn with_runtime_arg<K: Into<String>>(mut self, key: K, cl_value: CLValue) -> Self {
         match &mut self.body.args {
-            TransactionArgs::NamedArguments(named_args) => {
+            TransactionArgs::VmCasperV1(named_args) => {
                 named_args.insert_cl_value(key.into(), cl_value);
             }
-            TransactionArgs::Bytes(_) => {
+            TransactionArgs::VmCasperV2 { .. } => {
                 let mut named_args = RuntimeArgs::new();
                 named_args.insert_cl_value(key.into(), cl_value);
-                self.body.args = TransactionArgs::NamedArguments(named_args);
+                self.body.args = TransactionArgs::VmCasperV1(named_args);
             }
         }
         self
@@ -398,7 +398,7 @@ impl<'a> TransactionV1Builder<'a> {
     /// NOTE: this overwrites any existing runtime args.  To append to existing args, use
     /// [`TransactionV1Builder::with_runtime_arg`].
     pub fn with_runtime_args(mut self, args: RuntimeArgs) -> Self {
-        self.body.args = TransactionArgs::NamedArguments(args);
+        self.body.args = TransactionArgs::VmCasperV1(args);
         self
     }
 

--- a/types/src/transaction/transaction_v1/transaction_v1_header.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_header.rs
@@ -166,6 +166,10 @@ impl TransactionV1Header {
                 // TODO: Change this when reserve gets implemented.
                 0u8
             }
+            PricingMode::GasLimited {
+                gas_price_tolerance,
+                ..
+            } => gas_price_tolerance,
         }
     }
 


### PR DESCRIPTION
- Adds a TransactionArgs struct that has both RuntimeArgs (`vm-casper-v1`), and raw bytes (`vm-casper-v2`).
- Adds `PricingMode::GasLimited` which works like a `PricingMode::Classic` but does not involve a payment code, and the user specifies the limit which acts as collateral, and acts as a limit of computation. Any unused gas below the limit is subject to refunds as per chain config.